### PR TITLE
Bump commons-csv version.

### DIFF
--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -32,7 +32,7 @@
 	<name>d:swarm - Converter</name>
 
 	<properties>
-		<commons-csv.version>1.0-SNAPSHOT</commons-csv.version>
+		<commons-csv.version>1.1</commons-csv.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Version 1.0-SNAPSHOT seems to be gone:

http://repository.apache.org/content/groups/snapshots/org/apache/commons/commons-csv/
