### PR TITLE
[DD-1298] extend morphscriptbuilder to parametrize 'all' collector properly

### DIFF
--- a/converter/src/test/java/org/dswarm/converter/flow/test/xml/XMLTransformationFlowTest.java
+++ b/converter/src/test/java/org/dswarm/converter/flow/test/xml/XMLTransformationFlowTest.java
@@ -257,6 +257,26 @@ public class XMLTransformationFlowTest extends GuicedTest {
 		testXMLTaskWithTuples("dd-1298.task.result.json", "dd-1298.task.json", "fincmarc_small2.tuples.json");
 	}
 
+	/**
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testFincMiscDel152BeanShellScriptTask() throws Exception {
+
+		testXMLTaskWithTuples("misc_del152.task.result.json", "misc_del152.task.plain.json", "fincmarc_small2.tuples.json");
+	}
+
+	/**
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testFincMiscDel152BeanShellScriptTask2() throws Exception {
+
+		testXMLMorphWithTuples("misc_del152.task.result.json", "misc_del152.task.morph.xml", "fincmarc_small2.tuples.json");
+	}
+
 	@Test
 	public void testSqlMapTask() throws Exception {
 

--- a/converter/src/test/java/org/dswarm/converter/flow/test/xml/XMLTransformationFlowTest.java
+++ b/converter/src/test/java/org/dswarm/converter/flow/test/xml/XMLTransformationFlowTest.java
@@ -247,6 +247,16 @@ public class XMLTransformationFlowTest extends GuicedTest {
 		testXMLTaskWithTuples("not-equals.filter.function.task.result.json", "not-equals.filter.function.task.json", "test-mabxml.tuples.json");
 	}
 
+	/**
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testFincRVKBeanShellScriptTask() throws Exception {
+
+		testXMLTaskWithTuples("dd-1298.task.result.json", "dd-1298.task.json", "fincmarc_small2.tuples.json");
+	}
+
 	@Test
 	public void testSqlMapTask() throws Exception {
 

--- a/converter/src/test/resources/dd-1298.task.json
+++ b/converter/src/test/resources/dd-1298.task.json
@@ -1,0 +1,3261 @@
+{
+  "name": "Project: test (434d05f6-1527-4c7b-fc5c-88a694b39355)",
+  "description": "With mappings: rvk_test_2",
+  "job": {
+    "mappings": [
+      {
+        "uuid": "4c2baf05-a71a-1952-7b35-75bd671bcffe",
+        "name": "rvk_test_2",
+        "transformation": {
+          "uuid": "ef03a055-6447-ac9e-7b7a-99e9fa16a3cb",
+          "name": "transformation",
+          "description": "transformation",
+          "function": {
+            "type": "Transformation",
+            "uuid": "28074a12-cabf-6c72-fcc3-0b9fbddcbfba",
+            "name": "transformation",
+            "description": "transformation",
+            "components": [
+              {
+                "uuid": "d4f6eb23-d5a0-cb70-44e5-705e0f58c6ba",
+                "name": "component3848003a-0468-54c0-ebb6-23849b918813",
+                "description": "{\"x\":\"datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f\",\"y\":0}",
+                "function": {
+                  "type": "Function",
+                  "uuid": "Function-9ef5d298-d32f-44e7-a99c-b693c61269d2",
+                  "name": "equals",
+                  "description": "Returns the value only if equality holds.",
+                  "function_description": {
+                    "name": "equals",
+                    "dsl": "metafacture",
+                    "reference": "equals",
+                    "description": "Returns the value only if equality holds.",
+                    "parameters": {
+                      "string": {
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "parameters": [
+                    "string"
+                  ]
+                },
+                "output_components": [
+                  {
+                    "uuid": "31242d53-392f-78aa-64c7-d8b4711176ec"
+                  }
+                ],
+                "parameter_mappings": {
+                  "string": "rvk",
+                  "inputString": "datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f__0__"
+                }
+              },
+              {
+                "uuid": "31242d53-392f-78aa-64c7-d8b4711176ec",
+                "name": "componentf2c41458-109a-43c5-0137-a24724d7cb07",
+                "description": "{\"x\":\"datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f\",\"y\":1}",
+                "function": {
+                  "type": "Function",
+                  "uuid": "Function-d6eff38b-f967-477c-ab70-6ee53dd3109a",
+                  "name": "all",
+                  "description": "Outputs an unnamed literal with -true- as value if all contained statements fire.",
+                  "function_description": {
+                    "name": "all",
+                    "dsl": "metafacture",
+                    "reference": "all",
+                    "description": "Outputs an unnamed literal with -true- as value if all contained statements fire.",
+                    "parameters": {
+                      "value": {
+                        "type": "text",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "parameters": [
+                    "value"
+                  ]
+                },
+                "input_components": [
+                  {
+                    "uuid": "d4f6eb23-d5a0-cb70-44e5-705e0f58c6ba"
+                  }
+                ],
+                "parameter_mappings": {
+                  "inputString": "component3848003a-0468-54c0-ebb6-23849b918813,datafield_subfield_value__324446d7-4836-deb1-29eb-823ef62cf2bc__0__",
+                  "value": "${datafield_subfield_value__324446d7-4836-deb1-29eb-823ef62cf2bc__0__}"
+                }
+              }
+            ],
+            "function_description": null,
+            "parameters": null
+          },
+          "input_components": null,
+          "output_components": null,
+          "parameter_mappings": {
+            "__TRANSFORMATION_OUTPUT_VARIABLE__434d05f6-1527-4c7b-fc5c-88a694b39355__2": "__OUTPUT_MAPPING_ATTRIBUTE_PATH_INSTANCE__434d05f6-1527-4c7b-fc5c-88a694b39355__2",
+            "datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f__0__": "datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f__0__",
+            "datafield_subfield_value__324446d7-4836-deb1-29eb-823ef62cf2bc__0__": "datafield_subfield_value__324446d7-4836-deb1-29eb-823ef62cf2bc__0__"
+          }
+        },
+        "input_attribute_paths": [
+          {
+            "type": "MappingAttributePathInstance",
+            "uuid": "324446d7-4836-deb1-29eb-823ef62cf2bc",
+            "name": "datafield_subfield_value__324446d7-4836-deb1-29eb-823ef62cf2bc__0__",
+            "attribute_path": {
+              "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+              "attributes": [
+                {
+                  "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                  "name": "datafield",
+                  "uri": "http://www.loc.gov/MARC21/slim#datafield"
+                },
+                {
+                  "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                  "name": "subfield",
+                  "uri": "http://www.loc.gov/MARC21/slim#subfield"
+                },
+                {
+                  "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                  "name": "value",
+                  "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                }
+              ]
+            },
+            "filter": {
+              "uuid": "809d65e2-b67e-fa2b-72ae-1f97fc6fda62",
+              "name": null,
+              "expression": "[{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#tag\":{\"type\":\"REGEXP\",\"expression\":\"084\"}},{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#subfield\\u001ehttp://www.loc.gov/MARC21/slim#code\":{\"type\":\"REGEXP\",\"expression\":\"a\"}}]"
+            }
+          },
+          {
+            "type": "MappingAttributePathInstance",
+            "uuid": "ef8168a6-9d38-fada-90ec-126b53d9624f",
+            "name": "datafield_subfield_value__ef8168a6-9d38-fada-90ec-126b53d9624f__0__",
+            "attribute_path": {
+              "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+              "attributes": [
+                {
+                  "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                  "name": "datafield",
+                  "uri": "http://www.loc.gov/MARC21/slim#datafield"
+                },
+                {
+                  "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                  "name": "subfield",
+                  "uri": "http://www.loc.gov/MARC21/slim#subfield"
+                },
+                {
+                  "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                  "name": "value",
+                  "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                }
+              ]
+            },
+            "filter": {
+              "uuid": "4bda4e10-ffbe-ed1d-16d1-350a8c93a7c1",
+              "name": null,
+              "expression": "[{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#tag\":{\"type\":\"REGEXP\",\"expression\":\"084\"}},{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#subfield\\u001ehttp://www.loc.gov/MARC21/slim#code\":{\"type\":\"REGEXP\",\"expression\":\"2\"}}]"
+            }
+          }
+        ],
+        "output_attribute_path": {
+          "type": "MappingAttributePathInstance",
+          "uuid": "7227eb81-96d5-4e50-afdf-a15df4583a34",
+          "name": "__OUTPUT_MAPPING_ATTRIBUTE_PATH_INSTANCE__434d05f6-1527-4c7b-fc5c-88a694b39355__2",
+          "attribute_path": {
+            "uuid": "AttributePath-b6d40691-cffd-4716-b417-6d4e7204d8d2",
+            "attributes": [
+              {
+                "uuid": "Attribute-7e5995f2-a3e1-4807-b570-bb938de6a4e0",
+                "name": "id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "input_data_model": {
+    "uuid": "dad9b635-1860-0b93-6eb5-3cadc703e162",
+    "name": "test",
+    "description": null,
+    "configuration": {
+      "uuid": "b178d14f-a780-eca7-6abe-461933f1e5bd",
+      "name": null,
+      "description": null,
+      "resources": [
+        {
+          "uuid": "Resource-51501fe8-3004-4f20-b90f-676e7981d63c"
+        }
+      ],
+      "parameters": {
+        "storage_type": "marc21",
+        "record_tag": "record"
+      }
+    },
+    "schema": {
+      "uuid": "Schema-781d73f0-d115-462e-9b4c-ec23e4251c8d",
+      "name": "marc21 schema",
+      "attribute_paths": [
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c430826b-4bd6-4e29-9005-7eb795778076",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0f13ed14-7920-4832-ac67-5ceca147bd87",
+            "attributes": [
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ed6b3e41-d208-48cf-966a-9ea0e52ccd57",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a2eab260-c941-4fdc-960b-1eb457cee43b",
+            "attributes": [
+              {
+                "uuid": "Attribute-91326f5c-06db-4866-99c2-81fc27602267",
+                "name": "type",
+                "uri": "http://www.loc.gov/MARC21/slim#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0658cf97-4496-4b55-ab00-568b77ca7d93",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5ce0f899-83ba-4c3f-a66a-9c9b11dfcdc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-27b90dc4-fd53-414e-b389-76973ce68fb4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-42e72690-79c1-435f-8aad-faa6fd7da855",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9d32093-3689-4ddf-82b9-f1b0bbd232a8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c3c678a8-1fcc-4208-ac54-cb62cf2447d4",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ab0885ce-f6e9-4e5b-9a4b-d81750141afc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d7d218fa-cc94-4974-a3eb-4d4529e4d93f",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1a1fdc71-10ea-4cb3-92ad-f5537c73dad4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e7a3f55e-2726-4b5a-a03e-41cb177cde32",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-9d24e826-c70e-4691-921c-e2022ec13d5c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5560885f-b1d3-41d3-9914-e2eb6c7301cb",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc9c0051-4d1d-4c16-ab7a-ae722457f636",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b132ca2c-94d5-4db9-9c3c-f6046b78d9c5",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-74492463-6ee5-4ca5-b2d5-ad534babca8c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c02508a4-3022-4023-8fb9-ff56d3de3ab7",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0f4bb69d-03e2-4685-9d5d-22b26eb7d83e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bf27673a-71d9-44b9-aecd-ad241456478c",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc053aae-512b-4a19-9192-81496833e81e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8646a949-f1d2-4bac-9eba-8a0cd84ca4f9",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f40b07e0-a6d7-486c-a1e5-362b7afdff34",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c4043365-18b4-408a-9aa4-6de7a5d4d007",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ec4e249f-9b56-4206-bcfb-60d45f268636",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-33e9a9cb-ccfc-4d77-89b2-503f09d448e8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5f0bd291-d311-404b-a1d8-c15426e0111c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-70352f17-81c3-4854-84b0-a3dd850317ba",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eb34d1aa-b76e-4ca2-93b6-cfcbad7a849b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7b6ea240-aa91-444a-937f-6efc36d0ddc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3c325fcd-5f86-4d93-8530-468872c426a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-debd4384-3258-4e4b-a925-f0f32702fec8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-7eb8941b-59a4-434d-a443-4540a2b896bf",
+                "name": "ind1",
+                "uri": "http://www.loc.gov/MARC21/slim#ind1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-275b376d-ae3a-4f3f-8705-0a13f86c6aba",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1db98d03-ab89-4d28-8f13-6c87cf7cd3b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-8653be0d-5384-4110-bf66-8c4998072c3c",
+                "name": "ind2",
+                "uri": "http://www.loc.gov/MARC21/slim#ind2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e2401b88-3a04-4f23-81d4-2e16a38522e0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5a6f915f-8fac-45d7-93d5-68b236cb376c",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ace8ef6b-a082-46f8-82cf-89e4ff36b968",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7b18b43f-1c59-4c25-a44b-088b9304e663",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-12358ff1-0183-4201-a163-011c5fc7b4d9",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e9df1173-1792-4d25-927e-cd2abad97688",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc28eb70-8167-4c1b-98c4-4609f7255866",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-81bdf315-f7fd-4e23-b9da-a7c5381d4f31",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-01a2281f-dbe9-4c9a-8cc0-47576b48261a",
+                "name": "code",
+                "uri": "http://www.loc.gov/MARC21/slim#code"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3cf47be1-0929-42b0-85c3-eb911c2534ec",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        }
+      ],
+      "record_class": {
+        "uuid": "Clasz-2e24c5d4-db16-48b9-a8e7-f229287c55e4",
+        "name": "recordType",
+        "uri": "http://www.loc.gov/MARC21/slim#recordType"
+      },
+      "content_schema": {
+        "uuid": "ContentSchema-7bdcaacc-e0e4-43fd-949c-4a42fb54d99d",
+        "name": "marc21 content schema",
+        "record_identifier_attribute_path": {
+          "uuid": "AttributePath-5ce0f899-83ba-4c3f-a66a-9c9b11dfcdc1",
+          "attributes": [
+            {
+              "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+              "name": "id",
+              "uri": "http://www.loc.gov/MARC21/slim#id"
+            }
+          ]
+        },
+        "key_attribute_paths": [
+          {
+            "uuid": "AttributePath-7b6ea240-aa91-444a-937f-6efc36d0ddc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-debd4384-3258-4e4b-a925-f0f32702fec8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-7eb8941b-59a4-434d-a443-4540a2b896bf",
+                "name": "ind1",
+                "uri": "http://www.loc.gov/MARC21/slim#ind1"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-1db98d03-ab89-4d28-8f13-6c87cf7cd3b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-8653be0d-5384-4110-bf66-8c4998072c3c",
+                "name": "ind2",
+                "uri": "http://www.loc.gov/MARC21/slim#ind2"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-81bdf315-f7fd-4e23-b9da-a7c5381d4f31",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-01a2281f-dbe9-4c9a-8cc0-47576b48261a",
+                "name": "code",
+                "uri": "http://www.loc.gov/MARC21/slim#code"
+              }
+            ]
+          }
+        ],
+        "value_attribute_path": {
+          "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+          "attributes": [
+            {
+              "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+              "name": "datafield",
+              "uri": "http://www.loc.gov/MARC21/slim#datafield"
+            },
+            {
+              "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+              "name": "subfield",
+              "uri": "http://www.loc.gov/MARC21/slim#subfield"
+            },
+            {
+              "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+              "name": "value",
+              "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+            }
+          ]
+        }
+      }
+    },
+    "deprecated": false,
+    "data_resource": {
+      "uuid": "Resource-51501fe8-3004-4f20-b90f-676e7981d63c",
+      "name": "fincmarc_small2.xml",
+      "description": ".,mn.,mn.mn",
+      "type": "FILE",
+      "configurations": [
+        {
+          "uuid": "b178d14f-a780-eca7-6abe-461933f1e5bd",
+          "name": null,
+          "description": null,
+          "resources": [
+            {
+              "uuid": "Resource-51501fe8-3004-4f20-b90f-676e7981d63c"
+            }
+          ],
+          "parameters": {
+            "storage_type": "marc21",
+            "record_tag": "record"
+          }
+        }
+      ],
+      "resource_attributes": {
+        "path": "/home/tgaengler/git/dswarm/controller/tmp/resources/fincmarc_small2.xml",
+        "filesize": -1,
+        "filetype": "application/xml"
+      }
+    }
+  },
+  "output_data_model": {
+    "uuid": "5fddf2c5-916b-49dc-a07d-af04020c17f7",
+    "name": "Internal Data Model finc Solr",
+    "description": "Internal Data Model finc Solr",
+    "schema": {
+      "uuid": "Schema-5664ba0e-ccb3-4b71-8823-13281490de30",
+      "name": "finc Solr schema",
+      "attribute_paths": [
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-45510f73-7e52-4298-b527-a63b196e4146",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4b2a78dd-eb54-4b07-8099-f91cab891ee3",
+            "attributes": [
+              {
+                "uuid": "Attribute-ec24b350-09c3-4cfc-9676-cfba300063a0",
+                "name": "_version_",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/_version_"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f1244815-c0c3-4fdc-bdd0-388dbc7d8a86",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a0fdd134-0674-4138-9200-b06640862359",
+            "attributes": [
+              {
+                "uuid": "Attribute-e97702dd-f890-4b01-9c94-87eccb54737e",
+                "name": "recordtype",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/recordtype"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cee4d6ad-7eb9-435c-bdde-10ba3c86d958",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b6d40691-cffd-4716-b417-6d4e7204d8d2",
+            "attributes": [
+              {
+                "uuid": "Attribute-7e5995f2-a3e1-4807-b570-bb938de6a4e0",
+                "name": "id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a0b9799e-96d1-45a3-86f0-85e1cd628291",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bd398c12-5a0c-42d5-96ae-e7fdfd02314a",
+            "attributes": [
+              {
+                "uuid": "Attribute-43d75a5b-c1af-4995-acea-612ad4503e51",
+                "name": "fullrecord",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fullrecord"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1e30bea1-4f8b-4857-9c43-b86e45084ce8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e2347424-50d1-45ff-abf1-12e008831f5a",
+            "attributes": [
+              {
+                "uuid": "Attribute-4ca9d98f-6a94-4314-8dae-5a4a7fb9a982",
+                "name": "itemdata",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/itemdata"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-42a3304f-9419-467e-a78d-7a6f8917f58b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1b152978-09fc-4c02-8edb-bed1dbbf0e4f",
+            "attributes": [
+              {
+                "uuid": "Attribute-2c7f665e-9c3d-43c1-826c-63155c7674a7",
+                "name": "marc_error",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/marc_error"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2cb48c32-e9d4-43db-a01a-be01e83a6250",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f3bb6525-05c4-4923-8daf-bc3f4c941d81",
+            "attributes": [
+              {
+                "uuid": "Attribute-3526ad77-e01a-4559-baf9-67cad2449850",
+                "name": "allfields",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/allfields"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-82b2aa67-6c2d-41ae-835d-ecb57610a56c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-72ebf5f4-bd2f-41f0-94b7-64bf82edeb3b",
+            "attributes": [
+              {
+                "uuid": "Attribute-f08f19aa-ae88-432b-bc6d-a6d54ab40b29",
+                "name": "allfields_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/allfields_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-40bd661b-e9f5-4406-8638-8f6dcf242327",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2e4a9e81-b17c-4da6-ad29-5b9349168a6d",
+            "attributes": [
+              {
+                "uuid": "Attribute-55578b4f-e172-41cd-bdd6-b135630b3449",
+                "name": "fulltext",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fulltext"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1c7e8c24-e1e6-459a-95c0-f5ddceec5205",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-846c0d34-f9a1-4a9d-829b-aef771d41dee",
+            "attributes": [
+              {
+                "uuid": "Attribute-c34d6355-3e8a-4db8-95e5-4f821db92804",
+                "name": "spelling",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/spelling"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-70ac78e4-a9d1-4be8-84d3-894a8d46897c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-6716a9ee-b68c-4f9e-bb4c-cec6150e83bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-ca75340b-7167-4d08-8156-bf0ee2321088",
+                "name": "spellingShingle",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/spellingShingle"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-492a36cb-e2bf-4e18-8c77-b317eeea2a4f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fec00f9e-68ff-41ff-8e4b-cedb25aa0073",
+            "attributes": [
+              {
+                "uuid": "Attribute-f0c2d149-5475-4a00-90e1-0e70f865c358",
+                "name": "mega_collection",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/mega_collection"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a6192e44-904d-4dd3-9fe1-e60e9389dd6e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f7b99506-e4bc-4e10-a203-8d3b959a39af",
+            "attributes": [
+              {
+                "uuid": "Attribute-a508a706-b393-45d0-b2b2-056c51150d93",
+                "name": "mega_toplevel",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/mega_toplevel"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3ed06dd9-64b2-4cad-8bf6-8ce8f27dc99b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2d0c7eaf-e894-4d01-824a-3842ef48f3d5",
+            "attributes": [
+              {
+                "uuid": "Attribute-2ecd4759-c655-4d83-8677-9db666095f2b",
+                "name": "record_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/record_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5ca5a5ff-767e-4f74-a71e-46567f97ec2f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-aae45656-4503-4332-8f46-fbea50449f6a",
+            "attributes": [
+              {
+                "uuid": "Attribute-8054f36c-ccd1-4f60-9408-4217f6bf334d",
+                "name": "source_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/source_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1321437e-4d17-4e64-a2a3-3988b4a81912",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-09296992-9dab-44c1-9ff8-5caf4e9bb437",
+            "attributes": [
+              {
+                "uuid": "Attribute-07eadaef-5a5f-4bc8-98f1-2fb36fb13a24",
+                "name": "authorized_mode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/authorized_mode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3f05df93-6d8f-44f3-bae8-0d43b1ead319",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1ae2437a-c3b9-4276-8cbd-1d1ac32cffeb",
+            "attributes": [
+              {
+                "uuid": "Attribute-0be57ff7-b2ee-4346-b4ae-f5049b6bb210",
+                "name": "institution",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/institution"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cdf8f26a-b0b7-4c45-9a81-4a31ac43a969",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5f61302b-3a87-454e-9754-1074981248af",
+            "attributes": [
+              {
+                "uuid": "Attribute-62f09731-f931-4cdf-a4ee-cc5e8d46efe3",
+                "name": "signatur",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/signatur"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e4f31787-e3ea-40ce-8dc6-3ed418c7ca93",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7e496286-3572-49f8-a3aa-ee9dd640419a",
+            "attributes": [
+              {
+                "uuid": "Attribute-83afc0fa-c857-4b36-88e0-63284b987b69",
+                "name": "barcode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/barcode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-863d4278-b6a0-4183-931b-ad770767bcb2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a9e0645f-fb30-4283-b2ed-91fa7960c78d",
+            "attributes": [
+              {
+                "uuid": "Attribute-bd455c81-2edf-446e-8107-3d9df42af826",
+                "name": "rsn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rsn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-abe8ada5-e4ce-4c46-b2db-d1e36be5b820",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bb13fc0d-33cd-4137-a9b4-a080099ccfe8",
+            "attributes": [
+              {
+                "uuid": "Attribute-e2528674-db68-4f5c-86c8-b72d744d941d",
+                "name": "access_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/access_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-779b98ee-721a-4a7c-90f6-c1d00870735f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f6add4d4-153f-4dc3-b86d-48b998ce6ac7",
+            "attributes": [
+              {
+                "uuid": "Attribute-272c8d6e-6bc1-4744-b613-e66469dd23c6",
+                "name": "author_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e5824903-4602-4475-b4a5-dddc59c28d30",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-117e6917-2e43-41ef-af45-a575bc42f3ca",
+            "attributes": [
+              {
+                "uuid": "Attribute-6c20d048-81ad-4baa-a510-ca0281e0b51c",
+                "name": "topic_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9868f45-9b3f-4feb-b2fc-e54ade764941",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-de8fda4c-3da1-446c-a1f4-a0fb3a176278",
+            "attributes": [
+              {
+                "uuid": "Attribute-3bccbb7d-0fd9-4a7d-9fef-f66adcc8a36b",
+                "name": "author_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c0ff1dd3-dfa5-46b7-a017-d55ac26137a7",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5a253efd-6c3e-4143-9d97-704b9c5d35e0",
+            "attributes": [
+              {
+                "uuid": "Attribute-619200ad-9d94-4258-8cf5-8fc125b4b211",
+                "name": "author_corp_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f8fa60a4-30b5-4c69-aa98-8fd7cf5ab2f8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-37d5b54b-224f-486b-8721-22305a7fe912",
+            "attributes": [
+              {
+                "uuid": "Attribute-7fb9dffe-b6a1-46ec-8267-18d2cacedcce",
+                "name": "topic_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7874ddeb-5e32-43bd-bb85-53dbb52e3bb0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-afe323e3-f8e5-4ed1-b0e1-6f090601dd67",
+            "attributes": [
+              {
+                "uuid": "Attribute-187bb5af-b2f5-4fe4-987e-fdfd92ead455",
+                "name": "multipart_set",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_set"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ef186d99-ec60-4406-b18e-b24faf18494c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-32437a46-4773-4d5a-9002-70e0a895ce61",
+            "attributes": [
+              {
+                "uuid": "Attribute-400148f4-05d6-43bb-95bc-9a787047db85",
+                "name": "multipart_link",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_link"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-92f0483e-859e-499b-8c2d-8cb7ea1014a4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-af3d5c10-396c-4c41-80ff-4fda7693981b",
+            "attributes": [
+              {
+                "uuid": "Attribute-047349e7-a3a9-4593-a850-c662578f8234",
+                "name": "multipart_part",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_part"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-719aef39-cf1e-48d8-9cbe-16a4db17cbb8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-21172cc2-b76a-4255-8690-e8e9c76a02dc",
+            "attributes": [
+              {
+                "uuid": "Attribute-c6c48e35-f2a5-4bb3-909a-36b6474f047b",
+                "name": "purchase",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/purchase"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6970b5a1-de98-4c30-9bad-2320e00459a0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bcc2305d-849f-4faa-b345-555fc71aedff",
+            "attributes": [
+              {
+                "uuid": "Attribute-dc9b3971-26f2-490b-b7cc-ac9da9ac8179",
+                "name": "timecode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/timecode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0ed685fe-bb32-4046-9891-0fc477be28e3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d553e96d-e70e-4ecf-afe1-35efe5b2f3cc",
+            "attributes": [
+              {
+                "uuid": "Attribute-c19e8e2c-6c45-4093-9145-fd6238d1d4b1",
+                "name": "misc_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-23887293-3272-40d3-98e6-a3130843f9b2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-271f11c0-8a71-462b-ade3-cb4761e6b80b",
+            "attributes": [
+              {
+                "uuid": "Attribute-ee83c47a-5c4e-47e6-9351-e5fbe416095b",
+                "name": "misc_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-406c726b-45b8-4f97-84d8-2338cc5d109a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-16a0cdf6-3566-47b8-849c-c5262bac789d",
+            "attributes": [
+              {
+                "uuid": "Attribute-16d02c45-5b13-43bb-92df-52ae6a4a4fbb",
+                "name": "misc_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b8fc6274-e22b-4c40-b6c1-de7c71a51897",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-712103f9-8e6e-4f66-a489-d2c8c92175fa",
+            "attributes": [
+              {
+                "uuid": "Attribute-d3d7a931-7369-4fdc-a389-a1520ecaddba",
+                "name": "branch_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b8a2bce7-6e92-4896-9019-8d5fbfd21a9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-feedb067-0177-4976-97d3-ec241eac4602",
+            "attributes": [
+              {
+                "uuid": "Attribute-b8dba465-7683-4c89-a52a-4cdde85bee5b",
+                "name": "branch_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ef1ecf17-5fbd-48c7-915f-e879aa0a14cf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0e7581f0-45c5-4bbf-aba5-5fd0c8881543",
+            "attributes": [
+              {
+                "uuid": "Attribute-70232888-abe0-4ef7-b5fb-b78fc5f0ef1c",
+                "name": "branch_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-156ba2bb-2a68-4129-96c0-17a0891df1a8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bff7fb5b-e974-4816-837a-33f7d4fdb216",
+            "attributes": [
+              {
+                "uuid": "Attribute-84337d64-9ca0-4c40-a296-348d7ae697b7",
+                "name": "branch_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-84a961a7-bd56-484e-9877-4a7f6dc614a0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a557a60b-a71d-4219-a074-fd064ed1af15",
+            "attributes": [
+              {
+                "uuid": "Attribute-aaf69301-375f-46a5-901e-e249d66e6c2e",
+                "name": "branch_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5c21d4db-9258-4c1a-8124-fbcdddf7ad41",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-201363be-9979-49c0-a570-bd9bb75969bc",
+            "attributes": [
+              {
+                "uuid": "Attribute-f69f9f21-2017-4b20-b4d7-74d6eb412dce",
+                "name": "branch_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-548d860c-eb41-4ac7-b9b2-ce8ac7d9df64",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88337fb2-f345-4e6f-8522-531f1300dfdc",
+            "attributes": [
+              {
+                "uuid": "Attribute-08709c29-ff3a-47c6-b378-ea83ab38c7f4",
+                "name": "collcode_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-96958b37-5708-45fe-8405-cd30e7612f00",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-029a079a-42b8-4016-b147-eacb3d94309d",
+            "attributes": [
+              {
+                "uuid": "Attribute-98b82015-1af4-440f-9bef-2e794d413961",
+                "name": "collcode_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cb1770c3-2be7-4e48-9b89-ef29014fed88",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8bea53d6-be0a-4dd6-9c3f-96537899950a",
+            "attributes": [
+              {
+                "uuid": "Attribute-dfcc4da9-50d2-4e0f-9f4c-145ffbb544ff",
+                "name": "collcode_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-76e17f5b-d18b-40fb-8c09-5beb4634c34c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-01f57990-2a02-48bf-bee9-0444b5cdc2a6",
+            "attributes": [
+              {
+                "uuid": "Attribute-ab3705e7-736f-4425-9694-deebfb601405",
+                "name": "collcode_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7f4f5b93-c825-4c89-8feb-32ef62d8951b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c7830c0a-1fe2-4d38-8ceb-ac0ca90612ed",
+            "attributes": [
+              {
+                "uuid": "Attribute-d6c38983-1296-4b8e-9e75-b8bdc721f858",
+                "name": "collcode_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-df3b8895-b198-433f-b5c8-160daf8ef79c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-851ed5c4-4746-4114-b915-b0b179cc65bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-bff1a208-fc8b-4ea1-a57a-623c4af32b2e",
+                "name": "collcode_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4d6dc94a-2892-46d3-b3cd-ebc222b42ac7",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-12395c75-af94-4e25-8e85-df0b488cdda5",
+            "attributes": [
+              {
+                "uuid": "Attribute-aeb17052-b0f4-492b-8e16-2a2062108079",
+                "name": "format_de14",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de14"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a6a91254-b444-4732-856a-7f08cb680090",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f234260c-c82e-4ddd-85fa-632bdd7c8207",
+            "attributes": [
+              {
+                "uuid": "Attribute-fef965ba-3019-4a91-b8c3-7722280871ab",
+                "name": "format_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-de383eda-32f8-4965-aa95-36314fdca715",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a9bbd57b-ef0e-4fd2-adf5-bfa63d7f11ee",
+            "attributes": [
+              {
+                "uuid": "Attribute-7b45f142-ffb7-4324-8cd4-c043c296c401",
+                "name": "format_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cb3c78ac-0d0d-4d79-a84d-cfcf302cfc1a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-002c9305-e671-41b7-a772-aece230de2a3",
+            "attributes": [
+              {
+                "uuid": "Attribute-362c51fd-4644-42d2-8698-102a2368e4c7",
+                "name": "format_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-07603b06-32ac-4e5f-b589-a056175ea001",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f62c3555-05f8-4008-9cd2-91c9729ebbca",
+            "attributes": [
+              {
+                "uuid": "Attribute-227b906b-34a0-4876-91d8-094169182906",
+                "name": "format_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-02546aae-aa28-4bcd-8759-5912cae084a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9d9db34d-0829-4a25-886c-88446ec1f95a",
+            "attributes": [
+              {
+                "uuid": "Attribute-94828125-bbc7-4a58-9022-2e5e89475825",
+                "name": "format_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-21d9dcf9-c48b-45a2-a043-f69064e6d0af",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a25a9a1f-86c6-4b66-b1a6-7fe519db11b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-d2b7d786-4fa3-485b-8a79-7d11711e5af4",
+                "name": "format_del189",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_del189"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b78f4b3c-5db5-4241-bd1b-51d076bf2c09",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-67166209-afae-437b-85a9-d9bd6e363539",
+            "attributes": [
+              {
+                "uuid": "Attribute-d178877e-dab7-4c34-865c-f325c92a148f",
+                "name": "format_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-9c6a1d32-05d1-47f2-8ec1-10f0e1b70efc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8bfdf2bd-6174-4702-91fe-913323829cf3",
+            "attributes": [
+              {
+                "uuid": "Attribute-f171aa9a-1c35-41b4-8714-a76156e3b4bb",
+                "name": "format_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9952ece-bee8-4d5c-8822-d4daddaa4ad8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bd13a37c-4eb7-4b93-b7ba-a75158539ce6",
+            "attributes": [
+              {
+                "uuid": "Attribute-d32ce518-742b-4dcb-917c-a3f830ea96e9",
+                "name": "format_de540",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de540"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-32004942-ca80-4b3f-9fee-1cd331171de6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-dbb89ec5-f3b1-4c06-b6c9-b5bf3a305259",
+            "attributes": [
+              {
+                "uuid": "Attribute-3dd2dfe9-ddf8-4d30-b569-b96ebb733c60",
+                "name": "format_ded117",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_ded117"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-53f190f1-b92a-443a-a4d4-70baac388bde",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cb249ee6-e2b4-4d5c-ab0c-fe2e1405fa07",
+            "attributes": [
+              {
+                "uuid": "Attribute-c10d2ebf-053d-417f-8eb3-275eecb64340",
+                "name": "format_degla1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_degla1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2a9506bc-2452-41e6-a83b-e45c625a556c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a19a04ff-dc53-4dda-814f-8dc5385881fb",
+            "attributes": [
+              {
+                "uuid": "Attribute-5c2b0bec-acc9-43b0-998d-a44bd149d7e6",
+                "name": "local_heading_facet_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_facet_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-879471b7-eb9a-4fda-a059-849582b140eb",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-55e820c9-8f38-447f-91be-8d566e8cb3ba",
+            "attributes": [
+              {
+                "uuid": "Attribute-19fcf5ef-405b-441e-bce8-1d49ffc1a226",
+                "name": "local_heading_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-dea5f1ac-c510-4a97-b733-cbe8fb13894d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-622ea203-b737-4ae0-b899-6d50f23062ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-61da8eb2-e906-4d4d-88e5-a18292a3b628",
+                "name": "local_heading_facet_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_facet_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-04af741c-62d3-4aae-86b8-09440f4fb6e0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a3d2aba0-b90c-4694-aba1-fc4fa0e38878",
+            "attributes": [
+              {
+                "uuid": "Attribute-8dd4ff55-a35b-4717-bbeb-7a0a8c4b8c31",
+                "name": "local_heading_del242",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_del242"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-55c6e6d5-327d-49fb-9885-24f98b3f078d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-967ff8bc-d803-4231-9dad-3a6d4b651822",
+            "attributes": [
+              {
+                "uuid": "Attribute-cc88a7e7-64e2-4ce7-899c-22747efe4fc3",
+                "name": "local_class_del242",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_class_del242"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1ea5d761-d0c9-4deb-b601-e1e367c450bf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-38f53b9f-5d49-49d1-8419-dda43b2ad0ff",
+            "attributes": [
+              {
+                "uuid": "Attribute-09502570-bc59-432b-a2e4-d2321164ec57",
+                "name": "udk_raw_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_raw_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ae1a72c7-8760-4f99-98c1-a35156701e9f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-6b447de3-1c45-445a-9369-226d98878aab",
+            "attributes": [
+              {
+                "uuid": "Attribute-5e32d285-fcba-46d1-8070-a90bb9ad567c",
+                "name": "udk_facet_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_facet_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a9a8bbe1-0496-463d-b460-cd3b76df03ef",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c222aa48-28f9-4988-8ad3-8e807daad03f",
+            "attributes": [
+              {
+                "uuid": "Attribute-7790bc9b-882f-442d-bea9-117bab8da717",
+                "name": "udk_raw_del189",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_raw_del189"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1d67416c-e1c8-4332-87ce-a99cba0ee2b1",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0325f60b-41c2-4bde-b962-0a15184f2160",
+            "attributes": [
+              {
+                "uuid": "Attribute-e0c2c6bc-125c-4263-9e40-1b0bb47dec8d",
+                "name": "finc_class_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/finc_class_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-62573309-8896-456a-9de7-05599ba55dc0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bfdf59ff-5cf9-48b1-918f-9304a1543306",
+            "attributes": [
+              {
+                "uuid": "Attribute-c650f01f-2039-45e6-ad9f-8f55dba32d9e",
+                "name": "zdb",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/zdb"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0136c6af-ad95-4a93-91f0-ac88cd3ef1a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e5e0c447-3c5d-43f5-ad5f-1a7d7db14092",
+            "attributes": [
+              {
+                "uuid": "Attribute-6d7733d7-b565-4c21-a6c7-902a86fce5af",
+                "name": "format",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b2d4c8a1-f54c-4203-918b-c447f4977696",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c7b3f4d3-2c55-4540-bfcd-8c62689bfcfb",
+            "attributes": [
+              {
+                "uuid": "Attribute-a6391a20-786f-48f3-a5fa-9301019104cb",
+                "name": "language",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/language"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e3bafb46-a329-46fa-8630-b29f8e645a01",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f2089462-91a6-447a-bf8d-065093bad8d6",
+            "attributes": [
+              {
+                "uuid": "Attribute-55dd3a58-3321-4431-91db-cea98485a496",
+                "name": "author",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2fce5057-48ca-48ad-b6b2-f2c117234cab",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-08a5e77c-777b-4b49-bf34-30dc7e5c0d80",
+            "attributes": [
+              {
+                "uuid": "Attribute-ff02c40b-26bd-40a1-af9f-20e6361c9a2e",
+                "name": "author_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0bca34eb-020c-43d6-b08b-7774a134ede3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a427e79b-9c0c-45c3-a953-b58b0fe05799",
+            "attributes": [
+              {
+                "uuid": "Attribute-3fe3d35d-0513-4712-8f4c-b0acf5ff9daa",
+                "name": "authorStr",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/authorStr"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-497762b6-dc4f-4457-a6a7-98c6e14bf8cf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f3736cc7-ba6d-4a0b-a6b2-5f4c53e36b77",
+            "attributes": [
+              {
+                "uuid": "Attribute-297878f9-8227-4b3d-9eaa-be2043542a6d",
+                "name": "author2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4ee2b2ba-c619-4fe9-bb14-7ccb49d7cfcd",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f410d8e5-bbc6-4509-aab9-eda69a5a98c8",
+            "attributes": [
+              {
+                "uuid": "Attribute-d3f4b9ef-627f-48cf-8a52-d7e8624c64a5",
+                "name": "author2_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-fb043677-44da-469f-a72d-ca7c502394ea",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e62a26b1-cced-4271-8457-2e08cd52fe62",
+            "attributes": [
+              {
+                "uuid": "Attribute-8f60b09c-5178-4d92-8b65-4f58a1180074",
+                "name": "author_corp",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-8473db9b-a729-4d14-9168-b94974ff0928",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a2afb846-7d7e-4b90-b7f3-4b5d6e30516a",
+            "attributes": [
+              {
+                "uuid": "Attribute-459f7af6-bf42-4c01-858c-b6d3d4a47577",
+                "name": "author_corp_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-91a25bf2-c7bc-4811-ba85-2cceae590b48",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ec8aad81-7c4e-43b0-989d-c69744bee70e",
+            "attributes": [
+              {
+                "uuid": "Attribute-ab45987a-d76c-43f2-be8f-daaa09d9d525",
+                "name": "author_corp2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c71b2225-73e9-4ec6-b15a-94c9dc7ce572",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9ab4b00f-fb83-49ff-bc13-c912651dc6ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-bcae2d56-4272-470e-9d12-e2919bb4ed93",
+                "name": "author_corp2_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp2_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-443322e2-a38b-4193-911e-be972820df6f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e90517f6-8d1f-460f-9d7e-bd770525f1ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-f0d72d18-7bab-4779-a8c5-1edee0139405",
+                "name": "author2-role",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2-role"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eee6f32d-cd7e-4867-b1bf-b2a1b7b1c3be",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-db6fad77-6e64-403e-8f4b-806e97aad02f",
+            "attributes": [
+              {
+                "uuid": "Attribute-3a8a3149-7306-462f-baa1-68266c8c9460",
+                "name": "author_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-46450b18-bd1c-4f66-a414-ef35930cf884",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e457643a-bb33-4c5d-8010-935be46c72e6",
+            "attributes": [
+              {
+                "uuid": "Attribute-371848c1-ea63-418e-99e1-35955686cd40",
+                "name": "author_browse",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_browse"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-40ae93ee-39ed-4ad0-9b81-b83b2b29bb71",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-915f1e48-1330-4805-b6b4-d3dd44e0869e",
+            "attributes": [
+              {
+                "uuid": "Attribute-02c6ee32-24bb-4100-8fff-66a0ff2701db",
+                "name": "author_sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-46127f6d-2afb-40d5-8fc6-87af711fd31a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cd17dd86-8f17-4429-a5a3-896614a06890",
+            "attributes": [
+              {
+                "uuid": "Attribute-487a2007-4046-4389-9090-572269dd6f45",
+                "name": "title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-daaf5c43-65b1-4d81-8aca-cbd630904b9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1a875b16-aede-450f-bafe-8a8992470eae",
+            "attributes": [
+              {
+                "uuid": "Attribute-2db2d3c2-b0cb-480d-9a10-4f96c2db9da4",
+                "name": "title_part",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_part"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-50248c52-0a79-4604-b413-2daebda95742",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c0b37a18-45fe-4033-ab03-e24ab531a96f",
+            "attributes": [
+              {
+                "uuid": "Attribute-78641e6d-acbb-4aa1-9227-8e9ea9bc7710",
+                "name": "title_sub",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_sub"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ad984db9-8b89-4d1c-9d84-e5bb7efcf115",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ec049154-2b01-4e92-a2c6-8bb97c30608a",
+            "attributes": [
+              {
+                "uuid": "Attribute-325bb505-8d38-4601-8a32-4f8a0ab5baae",
+                "name": "title_short",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_short"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7ba1fb02-7674-4145-b26c-74e70cd822b6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e0c46b4e-0a5a-430d-af4b-d02afa8fb77f",
+            "attributes": [
+              {
+                "uuid": "Attribute-0c1d94be-ceda-45d5-8077-86178d2ccfd0",
+                "name": "title_full",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_full"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4a932a71-1013-4fb0-8dd9-3ff19756bcc8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4c3e93a5-9cc6-4c30-be5e-4b92ee538ea2",
+            "attributes": [
+              {
+                "uuid": "Attribute-04b2a48a-2ccb-45e1-97b0-d045c69d8c55",
+                "name": "title_full_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_full_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e419a38b-56aa-450c-a314-ba499f6ebff5",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e4a85fb9-772d-47c1-8858-3dc424770bd5",
+            "attributes": [
+              {
+                "uuid": "Attribute-96f5e779-9330-4493-8b25-99f1fee1ddad",
+                "name": "title_fullStr",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_fullStr"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-468a8c5e-6dc7-431d-894a-f06a6a2540f3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-980ad5ba-adbc-41e0-a917-86fa5cf49f38",
+            "attributes": [
+              {
+                "uuid": "Attribute-177d36df-8648-4442-b92d-53ff99be220d",
+                "name": "title_alt",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_alt"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-73015b22-c520-414f-908e-9e5d511e0d36",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a3d19067-81a3-47bb-abd9-932a538da843",
+            "attributes": [
+              {
+                "uuid": "Attribute-5970e8a7-2ae7-4b89-bc8c-8a0719269740",
+                "name": "title_uniform",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_uniform"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4623a91f-d71a-48a3-9fe4-2fa725c99135",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-236a98f2-3fb8-40ac-98d4-e0ef31d7ea2f",
+            "attributes": [
+              {
+                "uuid": "Attribute-47d6b213-b227-4eb1-91a2-9d41d4a9abfd",
+                "name": "title_old",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_old"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6afb9715-709a-4ec5-9280-f07cfbc60608",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-52f3ad2e-2a1d-4e9a-b04a-8105f020d216",
+            "attributes": [
+              {
+                "uuid": "Attribute-92540c74-8b68-427b-819d-e27f29563bbf",
+                "name": "title_new",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_new"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3e6e3518-6e43-4cc9-851d-06a792320547",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0953f733-881d-45b3-94af-f4f1646729a7",
+            "attributes": [
+              {
+                "uuid": "Attribute-99fc6669-2c26-46d7-9c25-afadea3cb76e",
+                "name": "title_sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1a11dbfe-707e-4a42-b117-a49fc378ecd4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b3634a12-60dc-49aa-a0ca-1747871a4a80",
+            "attributes": [
+              {
+                "uuid": "Attribute-427d5dc1-3d53-4958-b81b-2912340592cf",
+                "name": "title_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4facf7ea-9a9b-4a0a-acc7-c4cd77076e1a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0b49e4fa-dc96-45d3-a147-75ca4c72cc3a",
+            "attributes": [
+              {
+                "uuid": "Attribute-90405ad9-8e89-4900-969c-9a7d83497380",
+                "name": "series",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-48dc195c-afbf-4048-aa44-3feaefcf8708",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ac34bbb0-4766-4129-927d-a315148fc01a",
+            "attributes": [
+              {
+                "uuid": "Attribute-c734c6c5-e450-4b31-b7ac-f65ab0d37fc5",
+                "name": "series2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-85137629-1e06-4d9d-b041-57e2eb36ca24",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c6c26618-8368-4221-ae1f-505b2d6ecf5c",
+            "attributes": [
+              {
+                "uuid": "Attribute-e34103b2-42b4-4f0f-99f2-c1e9a3357804",
+                "name": "series_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b524b8c3-df48-4b04-906a-6cdded6b2374",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-636d3312-7182-44be-8cbe-2c55545ab19b",
+            "attributes": [
+              {
+                "uuid": "Attribute-ca72b45b-472e-48b3-ad46-95efaec41d11",
+                "name": "edition",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/edition"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-05656f8a-e444-4cca-9030-0b7460c69f5f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c997dd61-6389-43da-b9bb-395c6425f9bb",
+            "attributes": [
+              {
+                "uuid": "Attribute-4ccab8d5-7db5-47e4-b8fc-8a287d03b903",
+                "name": "publisher",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publisher"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5d7ff419-3ed2-4b10-9b36-33b085ba365f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4ad02801-b206-44bd-8fd1-dcbb3b5001bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-975f6c6f-5cd3-439a-a824-9a299c2eefb6",
+                "name": "publishDate",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishDate"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cdfe71fa-7c9f-4ac7-84aa-cf1a552c7401",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0ba007e8-1eab-4e35-bf39-3d5a2c296dfd",
+            "attributes": [
+              {
+                "uuid": "Attribute-b1433100-bbb5-4115-b750-d3f99e668a37",
+                "name": "publishDateSort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishDateSort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1acadceb-4acc-489a-96b3-4667cef4fb13",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-34a5cfdd-749b-479a-8b87-30b091185c36",
+            "attributes": [
+              {
+                "uuid": "Attribute-5b044e3f-44b2-40dd-89a3-173060b6d407",
+                "name": "imprint",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/imprint"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0547a298-041c-43bd-9378-c71792b5ff8c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1e726577-d19a-4f46-a8a3-f68e3347457a",
+            "attributes": [
+              {
+                "uuid": "Attribute-efb96920-2977-4765-8852-9cfba45ed1d3",
+                "name": "dateSpan",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dateSpan"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a8fe2609-b86d-4696-ba68-a24108873521",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-53f522af-d7e3-4d46-a17b-c9181f11ffd2",
+            "attributes": [
+              {
+                "uuid": "Attribute-de4b7c7a-79f6-47e4-a272-3b5eb4458cbc",
+                "name": "publishPlace",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishPlace"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6ab15dfd-5b88-4c6d-8572-8ee5f6bf7a1e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b8261464-fce9-4a97-900d-3b7063a87b08",
+            "attributes": [
+              {
+                "uuid": "Attribute-67256488-dbbd-4a31-80f1-67248e2eab0e",
+                "name": "physical",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/physical"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e623576c-416a-4ba9-ba7d-b1f1787fcc36",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ced60eda-c22f-463e-a561-bba8eb68a0f5",
+            "attributes": [
+              {
+                "uuid": "Attribute-ce1bfb8a-725c-41cc-8b4b-7d1b3338d620",
+                "name": "footnote",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/footnote"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0c36bcb6-e86e-4c38-8aad-3002b745ad02",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7c8e3dc9-e348-4c80-bc83-2aa8a1630901",
+            "attributes": [
+              {
+                "uuid": "Attribute-1c9321b2-3222-43c7-a837-385e61e100c4",
+                "name": "dissertation_note",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dissertation_note"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f6cd9e8a-236c-4b22-a726-7bdc3fafe31b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d7ce0263-9757-401f-967e-224911d58e74",
+            "attributes": [
+              {
+                "uuid": "Attribute-80e926e9-0006-47b4-8da2-2dadf45ccfce",
+                "name": "performer_note",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/performer_note"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1c6b77b1-d85c-42ec-99b9-9d29762e0094",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a469c3bd-59a7-4f57-a3dc-2b224fe92a19",
+            "attributes": [
+              {
+                "uuid": "Attribute-91b38329-cda8-469b-a544-b5fd99d58d2a",
+                "name": "illustrated",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/illustrated"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6d1bc20b-7e9c-4d7d-a9ff-aa478b76e9c9",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-08560bce-31df-4dcd-ae5d-c0e0f1d806c8",
+            "attributes": [
+              {
+                "uuid": "Attribute-27a96cf4-9d2c-4578-808d-bd85112da750",
+                "name": "contents",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/contents"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1ad9f73c-58f1-4337-90ae-15448fe02cd5",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d3b5fd3a-300d-47d8-8ed2-75219ad97e40",
+            "attributes": [
+              {
+                "uuid": "Attribute-c9e6048f-efdb-4338-8d7a-3213a973a0d2",
+                "name": "url",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/url"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d09529c3-79a8-4f18-8337-cf7c88a4f721",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88aca618-9546-459f-849e-f1b95579f93a",
+            "attributes": [
+              {
+                "uuid": "Attribute-c77ea1a6-5e58-4cc2-bdda-244d2952fb58",
+                "name": "urn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/urn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eddac1de-45ed-4798-8821-c24be427528f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-3a49110f-a49c-4e5b-b154-3a32243bbc43",
+            "attributes": [
+              {
+                "uuid": "Attribute-27041a00-187c-4377-b68d-e7bf3164abfd",
+                "name": "isbn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/isbn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d34e2398-b131-4983-95c3-b194442bfb8e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f17a74bc-e030-434e-933f-7cc91c043e6f",
+            "attributes": [
+              {
+                "uuid": "Attribute-48ca955f-736a-41d5-8d9d-b45434e69d08",
+                "name": "issn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/issn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-523a6892-5a6d-4fd9-90d2-1621b9299c2d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9b46cf70-8e2a-43fc-b4b4-0a2d21dc7a1a",
+            "attributes": [
+              {
+                "uuid": "Attribute-f027f8d9-9fbe-4893-abae-1ea694777eaa",
+                "name": "isbn_canc",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/isbn_canc"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5381addc-1063-4b9d-b6fa-71079433da15",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-509e8d73-5dab-4dae-96da-e6dbcb578ce3",
+            "attributes": [
+              {
+                "uuid": "Attribute-0ac2737b-6b1a-43d8-99b8-7670710a6959",
+                "name": "ismn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/ismn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6cc21fc1-3d78-4880-bc04-d7ebb8080a5c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-70ab5dda-9a58-4c15-8d9c-cef0ec7e2706",
+            "attributes": [
+              {
+                "uuid": "Attribute-386eb59d-7664-48ff-8d54-a8bdd1553cbd",
+                "name": "issn_canc",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/issn_canc"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-22be6fc3-070a-40ee-a5ba-88e84b6ee675",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-86dde771-713d-427e-bf93-2c74a08ec0d5",
+            "attributes": [
+              {
+                "uuid": "Attribute-22eb7275-2d2e-468e-bc04-37b562695c97",
+                "name": "oclc_num",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/oclc_num"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3eba4a0d-0a8a-440c-85ea-bb8d9e9fd1a1",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fe14cfc9-868c-43c9-9b91-65d385b9cd7a",
+            "attributes": [
+              {
+                "uuid": "Attribute-8034ba82-efd4-4d1d-ba43-bfa545b6a7b9",
+                "name": "topic",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-763d5e9f-f74a-48ba-860f-033a66f26308",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5c5bedb5-e0b3-4889-bad9-be6fc06a3146",
+            "attributes": [
+              {
+                "uuid": "Attribute-d6aa9884-eb9f-4475-9bd1-38ebe6f1461f",
+                "name": "topic_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a29ec24c-0912-40f0-98e0-dc3b3ea68514",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-75d71cb1-4c4c-4f39-85e5-7f38f102cd0c",
+            "attributes": [
+              {
+                "uuid": "Attribute-e6d0581d-be80-4549-a095-9cc9722b7a2e",
+                "name": "topic_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2e9102fb-d754-4c3a-8c24-4046273bc2b6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a392110a-ddb8-4b3e-bc3d-5e312cff0736",
+            "attributes": [
+              {
+                "uuid": "Attribute-6f44cd53-cd16-4940-a6cd-45015f2afe6d",
+                "name": "geogr_code",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/geogr_code"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-910999dd-6064-4bb2-9e8e-ac9ab3e08e89",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1e4b9c3e-f137-46fd-93d2-d0b19a8de017",
+            "attributes": [
+              {
+                "uuid": "Attribute-e6952569-a1d7-4a67-b09a-3f99a24dc514",
+                "name": "geogr_code_person",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/geogr_code_person"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-77a38ffb-8d50-465e-9c7d-828fec08a52b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fd26dbc7-a7ce-4174-ac39-487f47640054",
+            "attributes": [
+              {
+                "uuid": "Attribute-fb79a56c-b730-4224-8020-29523b20f44c",
+                "name": "music_heading",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/music_heading"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c7ae7ead-a6ba-4afb-a3fc-18c27dae0d9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e013bdd2-a242-4d2c-917b-2f0e8c9514a5",
+            "attributes": [
+              {
+                "uuid": "Attribute-9e028361-0824-4cbb-a857-d88872783401",
+                "name": "music_heading_browse",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/music_heading_browse"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-22fac459-ce7b-4212-8dd1-ae300fedd487",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cf2ffabb-13e0-4eeb-a1a5-c99816a7799e",
+            "attributes": [
+              {
+                "uuid": "Attribute-e7f51963-01bc-46ad-8b9b-75488cd7b58c",
+                "name": "film_heading",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/film_heading"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-56d5f795-5cf5-4270-ae81-d4d8310add5f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-33cb8e89-49d0-44df-a5b4-f60fd1983eb4",
+            "attributes": [
+              {
+                "uuid": "Attribute-b98e2493-6877-4f21-9dcd-d727437dde60",
+                "name": "dewey-hundreds",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-hundreds"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-309621b1-6be5-4af0-a4a4-6ee1e2a520c4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-09008fb8-40a1-4aee-ad6c-ed14f0b7280d",
+            "attributes": [
+              {
+                "uuid": "Attribute-60741df0-b13d-4cb7-bc94-45960655db9a",
+                "name": "dewey-tens",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-tens"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-61b82d24-7dba-47b0-aa15-89a2b941264a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8a70fbed-efcb-4408-b7ce-8c3363fb579c",
+            "attributes": [
+              {
+                "uuid": "Attribute-3a37045f-956e-4be8-8984-b9ee773a6dbf",
+                "name": "dewey-ones",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-ones"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-763777a2-2031-4353-a1cc-c7d89195c519",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-64b045d5-1fbd-478e-ba37-59dc4c705ee7",
+            "attributes": [
+              {
+                "uuid": "Attribute-8beba31c-fac7-4619-a907-ef23388570ff",
+                "name": "dewey-full",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-full"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-fb483db6-9ab3-4d7c-8266-bcbc98680603",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-44bf98f8-1dd7-49bd-8f22-09c91e44549b",
+            "attributes": [
+              {
+                "uuid": "Attribute-8fe04556-7538-43a2-8fe4-6f2d9d399abb",
+                "name": "dewey-sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-42959947-742b-4f35-b9b1-a222e151e22f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4b5f473e-42cd-4bdb-a162-a0dd53b4d1da",
+            "attributes": [
+              {
+                "uuid": "Attribute-28d63692-1ed8-47a6-a024-4bdfb5819860",
+                "name": "dewey-raw",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-raw"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-77c22271-8a39-4f2d-959a-9b1e374a296e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7a76b8d1-4666-4a39-a2d9-64b0093446b2",
+            "attributes": [
+              {
+                "uuid": "Attribute-b25d0c23-bb48-4c68-b8ad-8277bdde020e",
+                "name": "rvk_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4660e13e-2a88-4e5b-86ed-432cdc7ec509",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8deb4cc9-fa96-4e59-ab33-b6b0410975e7",
+            "attributes": [
+              {
+                "uuid": "Attribute-fc57edb2-22c8-4853-9974-a8a027598217",
+                "name": "rvk_label",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_label"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-82dee949-280e-4e8f-8da1-8e07f877bb59",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8403bb86-9324-4ab3-822b-c1b26488ce45",
+            "attributes": [
+              {
+                "uuid": "Attribute-9ec2c755-5a1d-4c24-8fe0-200e917ca608",
+                "name": "rvk_path",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_path"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-8f0cd9cc-16f2-4fea-879b-4db11447811f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e1673ffa-4c4e-4cb2-9a3f-32cac6f4f6ef",
+            "attributes": [
+              {
+                "uuid": "Attribute-ef5fe1cd-1085-4e87-b572-087ac5f41a32",
+                "name": "fulltext_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fulltext_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d3e466dc-c776-4aca-8954-517f599d89e2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5cfe2b1c-3710-4bae-968e-2301799d784f",
+            "attributes": [
+              {
+                "uuid": "Attribute-2e8f4f1e-e346-48c9-aa5f-abfcd158ee77",
+                "name": "hierarchytype",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchytype"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-20faaea7-5253-4c4d-b3e4-7498a832060c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88be106f-8115-435a-9728-52eb1cb774a8",
+            "attributes": [
+              {
+                "uuid": "Attribute-89d67eeb-843d-4449-9abd-ff1d3a81be43",
+                "name": "hierarchy_top_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_top_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5b9eac9d-8e8d-4e70-ae0e-5133d52bbed8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-10d11291-16bc-48ec-93c2-0f7fa66eb366",
+            "attributes": [
+              {
+                "uuid": "Attribute-34345b9d-aea6-4ad5-8568-3f84e80ed254",
+                "name": "hierarchy_top_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_top_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-faf30109-1d09-4710-a6c4-88493c8951bc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f6c9d8c5-8c1d-41f1-b7b8-e7dc93a0c92a",
+            "attributes": [
+              {
+                "uuid": "Attribute-0e424e47-fa90-450a-95e8-b90bb24a8773",
+                "name": "hierarchy_parent_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_parent_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5442e5a5-0e18-4755-b48d-52df1e783b1d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-51fbce44-f7c6-4c9c-a02e-33d74692bb8c",
+            "attributes": [
+              {
+                "uuid": "Attribute-012edad4-f98f-47de-8935-e3b22d7e9166",
+                "name": "hierarchy_parent_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_parent_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b0890edf-fcc3-48ba-b70d-4f742bca6cc8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fc2137d6-0d94-46a9-a3c2-20cacaac0757",
+            "attributes": [
+              {
+                "uuid": "Attribute-53d34b5b-906b-4ac4-8423-28617ff088b5",
+                "name": "hierarchy_sequence",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_sequence"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4dec0fc2-ca74-4a62-89f2-85f8d93f422e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-909adff6-a3ff-4957-9ea5-287cb46aa3a3",
+            "attributes": [
+              {
+                "uuid": "Attribute-1e8679be-06d7-4da9-a4cb-80b7e52ecfb0",
+                "name": "is_hierarchy_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/is_hierarchy_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-dee9f51c-b6ad-4786-9e02-12e7c077cc66",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2b040adc-ab6c-45a3-bc17-cb77c9382b61",
+            "attributes": [
+              {
+                "uuid": "Attribute-2a8a468d-71ec-4679-b93a-f0d0ebc67620",
+                "name": "is_hierarchy_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/is_hierarchy_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d9a75478-c5f3-4fda-a555-6f407baea89d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-3dbbbe8f-d30c-48b9-baba-358864c4893c",
+            "attributes": [
+              {
+                "uuid": "Attribute-aba9c36f-acb7-4935-928e-519c1a6d68a6",
+                "name": "container_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-659cf4f4-e3af-4b0a-bc4b-b7c947326c77",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-17f137a3-89c0-42c7-9382-9dd28c99bc91",
+            "attributes": [
+              {
+                "uuid": "Attribute-e7ea27db-7ded-4d27-bf17-a4b698c1ab4b",
+                "name": "container_volume",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_volume"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6f3f3764-25ec-405f-ba78-3e1cacdce137",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-60fc6d36-f229-4f6f-bd63-67658f2c7cac",
+            "attributes": [
+              {
+                "uuid": "Attribute-785b23b5-72c2-4cf4-8ab6-543b6c7c00e1",
+                "name": "container_issue",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_issue"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-571beb5c-aed1-40fc-8f26-2aff6ca483ab",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8d9aa9b5-4807-4467-8b02-ae044f9907d2",
+            "attributes": [
+              {
+                "uuid": "Attribute-753c3a74-1560-458b-b3aa-d569c296d71f",
+                "name": "container_start_page",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_start_page"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f6947f40-6a19-4d3e-b435-71a72a7b41c2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0a73af76-e9f0-4ce4-b852-e0df180fba74",
+            "attributes": [
+              {
+                "uuid": "Attribute-83a14db9-ae35-48e2-9264-0127fbe1b6a9",
+                "name": "container_reference",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_reference"
+              }
+            ]
+          },
+          "sub_schema": null
+        }
+      ],
+      "record_class": {
+        "uuid": "Clasz-2b3ddd78-3876-44eb-bdd9-ae817ca563c8",
+        "name": "RecordType",
+        "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      },
+      "content_schema": {
+        "uuid": "ContentSchema-b321979d-f31e-45b7-b687-39b00f7cb440",
+        "name": "finc Solr content schema",
+        "record_identifier_attribute_path": {
+          "uuid": "AttributePath-b6d40691-cffd-4716-b417-6d4e7204d8d2",
+          "attributes": [
+            {
+              "uuid": "Attribute-7e5995f2-a3e1-4807-b570-bb938de6a4e0",
+              "name": "id",
+              "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id"
+            }
+          ]
+        },
+        "key_attribute_paths": null,
+        "value_attribute_path": null
+      }
+    },
+    "deprecated": false
+  }
+}

--- a/converter/src/test/resources/dd-1298.task.result.json
+++ b/converter/src/test/resources/dd-1298.task.result.json
@@ -1,0 +1,119 @@
+[
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/edc8b99d-9eeb-495b-b66e-ea3f468f3015": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/24be24bd-b7fb-4d34-98c1-bc2208c6fb95": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "SI 850"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/45f7a59a-e684-4ea5-bca2-bebc04bde61f": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": [
+          "UO 1100",
+          "SD 1985",
+          "UD 1985"
+        ]
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/159417cb-3560-4d0b-af35-288445264677": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": [
+          "QK 300",
+          "QK 490",
+          "QK 370"
+        ]
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/cc0ddde4-1c91-4854-94dc-2f92eb4eab38": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "SI 805"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/be0d884e-873e-469f-9c6e-4f323ef29e49": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/057465fc-b327-441f-91ba-86d6e5657e2d": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "SI 850"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/ebc2b1bb-965a-476c-955e-f8be08766199": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "BO 6490"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/0ec7ff0c-8463-44a8-b374-dec8ad540365": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": [
+          "ND 8730",
+          "ND 8700",
+          "NM 7250",
+          "NW 7000"
+        ]
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/dd84832f-520e-4e1f-a119-5047a536eeef": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "SI 850"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/3ecc9911-d1e9-4a32-b0b4-eaa15f3fd75e": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id": "DF 9000"
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      }
+    ]
+  }
+]

--- a/converter/src/test/resources/fincmarc_small2.tuples.json
+++ b/converter/src/test/resources/fincmarc_small2.tuples.json
@@ -1,0 +1,11968 @@
+[ {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/edc8b99d-9eeb-495b-b66e-ea3f468f3015",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02355cam a2200733 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061171"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20150211073247.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1988 xx m 000 0 ger c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)310869390"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ014243539"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dt."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Heiden, Christoph von"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164869948"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Motivation und Kommunikation :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "kritische Bilanz und Modifikation einer theoretischen Perspektive /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "vorgelegt von Christoph von der Heiden"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1988"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "390 S. :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "graph. Darst."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "502"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Münster, Univ., Diss., 1987."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "580 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4031883-7"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208994653"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kommunikation"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4040364-6"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209039698"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Motivation"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4059360-5"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209130482"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Telekommunikation"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4026927-9"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208968555"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Informationstheorie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "751"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Münster (Westf)"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "uvp"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "m"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "V:DE-605;X:Imageware"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "q"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "application/pdf"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=3143028"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "hs"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-14)1311412"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "984"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0012068830"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Keine"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1406250"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "HS"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "VonDerHeiden, Christoph"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DerHeiden, Christoph von"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Nachrichtentheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kybernetik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Motiv"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Verhalten"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Motivation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Verhaltensmotivation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Selbstmotivation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Selbstmotivierung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Antrieb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Telekommunikationstechnik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Telekommunikationstechnologie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kommunikation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Nachrichtenwesen"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Informationstechnik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Fernmeldewesen"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Neue Medien"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Nachrichtentechnik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kommunikationsprozess"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Informationsprozess"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Informationsaustausch"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kommunikationssystem"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kommunikationspartner"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-14"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2014-03-15T18:29:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-06-21T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014243539"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201502120428"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/24be24bd-b7fb-4d34-98c1-bc2208c6fb95",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02591cam a22006612 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061173"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20140805164105.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1988 xx 100 0 eng c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "015"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "88,N20,0196"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dnb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)17981068"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880596139"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-101"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3540193405"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3-540-19340-5"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0387193405"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0-387-19340-5"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)DNB880596139"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "510"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "514/.2"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SA - SP"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 830 - SI 910"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic topology, rational homotopy :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "proceedings of a conference held in Louvain-la-Neuve, Belgium, May 2 - 6, 1986 / "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Y. Felix (ed.)"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Berlin ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Heidelberg [u.a.] :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Springer,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1988"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "VIII, 245 S."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1318"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4120861-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209538570"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraische Topologie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Louvain-la-Neuve <1986>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4177003-1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209974494"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Rationale Homotopietheorie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Louvain-la-Neuve <1986>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Félix, Yves"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1951-"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hrsg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)111765560"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)16095911X"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "edt"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "775"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "i"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Online-Ausg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Félix, Yves"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "t"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic Topology Rational Homotopy"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)404653278"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "830"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics <Berlin>"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1318"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)015703274"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "m"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576;springer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "q"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "image/jpeg"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://swbplus.bsz-bw.de/bsz014243989cov.htm"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20091126143631"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Cover"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1792970&custom%5Fatt%5F2=simple%5Fviewer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "y"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic topology, rational homotopy"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gkko"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen in der alphabetischen Ordnung nach Verfassern"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9780387193403"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9783540193401"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0008620947"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)SI 850-1318"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)Sb4 - 16:1318"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FHMath"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1416428"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Félix, Y."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Homotopietheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Homologische Algebra"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Topologie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "107532085:201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-08-01T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014243989"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201502081250"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/45f7a59a-e684-4ea5-bca2-bebc04bde61f",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "03360cam a22008652 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061169"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20150409161154.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1985 xx 100 0 eng c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)241565412"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9971978695"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9971-978-69-5"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9971978725"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9971-978-72-5"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ01424280X"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "UO 1100"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SD 1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SA - SP"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SD"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SD 1985"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "UD 1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "111"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Symposium on Anomalies, Geometry, Topology"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Chicago, Ill."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)1098719-8"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)192683624"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Symposium on Anomalies, Geometry, Topology :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "March 28-30, 1985 /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ed. by William A. Bardeen ..."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Singapore :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "World Scientific,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "XVIII, 558 S. :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "graph. Darst."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb; 580 ff. bvb ; 5090: HDBSPY"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4014414-8"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208907580"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Elementarteilchenphysik"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4060425-1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209135239"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Topologie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "3"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Chicago <Ill., 1985>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4020236-7"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208932496"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geometrie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4122125-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209548932"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Eichtheorie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "3"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Chicago <Ill., 1985>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4224277-0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)210296739"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Superstringtheorie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Chicago <Ill., 1985>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bardeen, William A."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hrsg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164869654"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "edt"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gkko"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "UO 1100"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongresse, Symposien, Sommerschulen zum Gesamtgebiet Elementarteilchen und Felder "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Physik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Elementarteilchenphysik, Physik der Felder und Hochenergiephysik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Elementarteilchen und Felder"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongresse, Symposien, Sommerschulen zum Gesamtgebiet Elementarteilchen und Felder "
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SD 1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongressberichte ( Geordnet nach Kongreßjahr mit Cutter-Sanborn-Notation des Kongreßortes, z.B. erhält ein Kongreß von 1960 in Moskau die Signatur SD 1960 M911) "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "UD 1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Physik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongresse, Sommerschulen, geschlossen aufgestellte Serien"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongresse allgemeiner oder theoretisch-physikalischer Thematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1985"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9789971978693"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9789971978723"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0010239224"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)SD 1985 C532"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)87-8-31057"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FH"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1265630"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Eichfeldtheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Gauge-Theorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Eichfeld"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Theorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Feldtheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Eichtransformation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Analysis situs"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geometrie der Lage"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Teilchenphysik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Elementarteilchentheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Moderne Physik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hochenergiephysik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Stringtheorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Supersymmetrie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kaluza-Klein-Theorie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Supergravitation"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Höherdimensionale Raum-Zeit"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wechselwirkung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Vereinheitlichung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2004-05-11T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "01424280X"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201504100247"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/159417cb-3560-4d0b-af35-288445264677",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02980cam a2200817 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061170"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20130516194235.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1984 xx m 000 0 ger c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "015"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "84,H12,0092"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dnb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)16468414"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "841031622"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-101"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3781930122"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3-7819-3012-2"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)DNB841031622"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dt."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Q"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300 - QK 380"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Q"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 400 - QK 490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 490"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 370"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Q"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300 - QK 380"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 305 - QK 380"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 370"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lubitz, Karl-Joachim"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164046135"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bankmarketing gegenüber mittelständischen Betrieben /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "von Karl-Joachim Lubitz"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Frankfurt am Main :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Knapp,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1984"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "299 S."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bank- und Geldmarketing"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "502"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Zugl.: Berlin, Freie Univ., Diss., 1984."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SW:580 FGBA/S+Wei ; 720 ff. bvb ; 5090: DDSU/sred"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4004436-1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208855866"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bank"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4037589-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209025417"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Marketing"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "751"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Berlin"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "pup"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "hs"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wirtschaftswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geld, Kredit- und Bankwesen. Bankbetriebslehre"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bankbetriebslehre"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreditversorgung einzelner Wirtschaftszweige und einzelner Regionen. Staatliche Finanzierungshilfen "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wirtschaftswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geld, Kredit- und Bankwesen. Bankbetriebslehre"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschäftsbanken. Sparkassen. Kreditgenossenschaften. Spezialbanken"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreditversorgung einzelner Wirtschaftszweige und einzelner Regionen. Staatliche Finanzierungshilfen "
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 370"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bank-Marketing"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wirtschaftswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geld, Kredit- und Bankwesen. Bankbetriebslehre"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bankbetriebslehre"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bankmanagement"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bank-Marketing"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9783781930124"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-14)945165"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "984"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-Ch1)000000020258"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "971"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "F"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-Ch1)S1:251896"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "971"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "M"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-Ch1)500109508"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "971"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-105)94.5541/18."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "972"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FBF"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-105)500069993"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "972"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "HS"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "972"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "i"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-105)94.5541 8."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "972"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "h"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "94.5541 8."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "972"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "f"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "QK 300"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bankbetrieb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Banken"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreditinstitut"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreditwesen"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Absatzwirtschaft"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Konsumgütermarketing"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Marketingpolitik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Verbrauchsgut"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Marketing"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Verbrauchsgütermarketing"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Absatzpolitik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Absatzplanung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Verkaufsplanung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Absatz"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-14"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2014-03-15T17:58:10Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-105"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1997-02-20T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-Ch1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2004-07-06T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014242931"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201403052225"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/cc0ddde4-1c91-4854-94dc-2f92eb4eab38",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02186cam a2200505 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061176"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20111001013854.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1987 xx 100 0 eng c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)16900235"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "082185075X"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0-8218-5075-X"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ014244586"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "516.3/6"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 805"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SA - SP"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 109 - SI 805"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 805"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Differential geometry: the interface between pure and applied mathematics :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "proceedings of a conference held April 23 - 25, 1986 with support from the National Science Foundation / "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mladen Luksic ..., eds."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Providence, RI :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "American Mathematical Society,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1987"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "IX, 273 S."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Contemporary mathematics ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "68"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb; 580 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4012248-7"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208897666"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Differentialgeometrie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "San Antonio <Tex., 1986>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Luksic, Mladen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hrsg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164870547"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "edt"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "711"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Conference on Differential Geometry"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1986"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "San Antonio, Tex."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)624186-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)193125102"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "830"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Contemporary mathematics"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "68"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)01610207X"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1900582&custom%5Fatt%5F2=simple%5Fviewer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "y"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Differential geometry: the interface between pure and applied mathematics"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gkko"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 805"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Contemporary Mathematics. Hrsg.: American Mathematical Society"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen in der Ordnung der Bandzählung"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Contemporary Mathematics. Hrsg.: American Mathematical Society"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9780821850756"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0008629625"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)SI 805-68"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)12929"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)Sb4 - 159:68"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FHMath"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1370077"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geometrie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "10753536X:201403052111"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-04-11T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014244586"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201403052111"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201410032207"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/be0d884e-873e-469f-9c6e-4f323ef29e49",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "00729 a2200229 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0004438744"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "q"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "590"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Baroque"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "384"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "G"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "590"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "orchestra, continuo, voices"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Galuppi, Baldassare"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "L'uomo femina"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://imslp.org/wiki/L%27uomo%20femina%20%28Galuppi%2C%20Baldassare%29"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Petrucci-Musikbibliothek"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "970"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "PN"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-14"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2015-07-01T12:31:12Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2013-07-26T08:25:38Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-1972"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2015-12-01T10:19:03Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-1156"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2015-12-01T10:19:03Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-D117"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2014-07-08T18:02:31Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-L152"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2013-07-26T08:25:38Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-Kn38"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2015-12-01T10:19:03Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "8557aa2921c0b2d6926167e4d4b23dbd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20130724"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/057465fc-b327-441f-91ba-86d6e5657e2d",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02429cam a2200613 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061174"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20140805164105.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1988 xx 00 0 eng c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)18236825"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3540192352"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3-540-19235-2"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0387192352"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0-387-19235-2"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ014244209"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "510"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "516.3/5"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SA - SP"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 830 - SI 910"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Laudal, Olav Arnfinn"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1936-"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)109296370"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)351748709"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Local moduli and singularities /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Olav Arnfinn Laudal; Gerhard Pfister"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Berlin ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Heidelberg [u.a.] :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Springer,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1988"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "V, 116 S."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1310"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb ; 720 ff. (DDC): GBV/LOC"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4077459-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209205237"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Singularität"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g:Mathematik"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4200385-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)210135093"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Moduliproblem"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-101"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Pfister, Gerhard"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1947-"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)133185273"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)162541562"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "aut"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "775"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "i"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Online-Ausg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Laudal, Olav Arnfinn"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "t"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Local Moduli and Singularities"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)404653219"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "830"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics <Berlin>"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1310"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)015703274"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "m"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576;springer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "q"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "image/jpeg"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://swbplus.bsz-bw.de/bsz014244209cov.htm"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20091126143444"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Cover"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1950714&custom%5Fatt%5F2=simple%5Fviewer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "y"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Local moduli and singularities"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen in der alphabetischen Ordnung nach Verfassern"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9783540192350"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9780387192352"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0008621015"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)SI 850-1310"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)Sb4 - 16:1310"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FHMath"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1416386"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Pfister, G."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Laudal, Olav A."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Laudal, Arnfinn"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Laudal, O. A."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Singuläre Stelle"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Singulärer Punkt"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "951"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "XA-NO"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "107533049:201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-08-01T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014244209"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201502081250"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/ebc2b1bb-965a-476c-955e-f8be08766199",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "01809cam a2200505 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061167"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20150518124849.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1924 xx 00 0 c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)257830221"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ014241463"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 6490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 2000 - BO 7050"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 5850 - BO 6550"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 5950 - BO 6550"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 6480 - BO 6490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 6490"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ssgn"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Skolaster, Hermann"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164869387"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Die Pallottiner in Kamerun :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "25 Jahre Missionsarbeit /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "von Hermann Skolaster"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Limburg/Lahn :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Dr. u. Verl. d. Kongregation d. Pallottiner,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1924"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "327 S. :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Ill., Kt."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "500"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "In Fraktur."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb; 580 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4029413-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208982442"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kamerun"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4039567-4"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)20903551X"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mission"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "z"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte 1890-1915"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "mteo"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "BO 6490"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Nach Kontinenten"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Theologie und Religionswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Patrologie und Kirchengeschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kirchengeschichte nach Perioden"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Von der Französischen Revolution bis Pius XII. (1789-1958)"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Darstellungen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Missionsgeschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Nach Kontinenten"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0011252696"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)A 40183"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)KG 65/286"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Keine"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1389366"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Christentum"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mission"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Christliche Mission"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Heidenmission"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Weltmission"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Missionierung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Christianisierung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kameruner"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "951"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "XC-CM"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-04-26T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014241463"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201505190436"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/0ec7ff0c-8463-44a8-b374-dec8ad540365",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "03352cam a2200769 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061168"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20121113134618.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1988 xx 00 0 ger c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "015"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "88,N03,0725"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dnb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "015"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "88,A24,1442"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dnb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)19761505"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880106697"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-101"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3593338831"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3-593-33883-1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)DNB880106697"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "fre"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dt."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "franz."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "325.4"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8730"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "N"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8700 - ND 8780"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8730"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8700"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "N"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8700 - ND 8780"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8700"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM 7250"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "N"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM 5400 - NM 7470"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM 7230 - NM 7470"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM 7250"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NW 7000"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "N"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NW"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NW 7000 - NW 9000"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NW 7000"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Migration in der Feudalgesellschaft /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Gerhard Jaritz; Albert Müller (Hg.)"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Frankfurt/Main ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "New York :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Campus-Verl.,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1988"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "403 S."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Studien zur historischen Sozialwissenschaft ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "8"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "500"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Literaturangaben. - Beitr. teilw. dt., teilw. engl., teilw. franz."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4039677-0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209036133"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mitteleuropa"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4131524-8"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209627972"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Feudalismus"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4120730-0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209537477"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Migration"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "3"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Aufsatzsammlung"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-101"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Jaritz, Gerhard"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1949-"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hrsg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)118992902"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)161576605"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "edt"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "830"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Studien zur Historischen Sozialwissenschaft"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "8"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)013511068"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "m"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "V:DE-605;X:Imageware"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "q"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "application/pdf"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=2954316"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8730"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Einzelne Probleme und Beiträge (Geburten, Empfängnisverhütung, Ehestatistik, Scheidung, Sterblichkeit etc.) "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Historische Hilfswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Historische Demographie"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Einzelne Probleme und Beiträge (Geburten, Empfängnisverhütung, Ehestatistik, Scheidung, Sterblichkeit etc.) "
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ND 8700"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeine und Gesamtdarstellungen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Historische Hilfswissenschaften"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Historische Demographie"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeine und Gesamtdarstellungen"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NM 7250"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Einzelbeiträge"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte des Mittelalters"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Abendländische Geschichte im Mittelalter nach Zeitabschnitten"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Spätmittelalter (1250 - 1519)"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Einzelbeiträge"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "NW 7000"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wirtschafts- und Sozialgeschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Spezielle Sozialgeschichte"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9783593338835"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0013431012"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FHOmag"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1406901"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-14)148248"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "984"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Zentraleuropa"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Central Europe"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Feudalgesellschaft"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Feudalsystem"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Feudalistisches Gesellschaftssystem"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Gesellschaftsordnung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lehnswesen"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Bevölkerungswanderung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wanderung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wanderungen"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Wanderungsbewegung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mobilität"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Regionale Mobilität"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "951"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "XA"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-14"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2014-03-15T17:30:09Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-06-23T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014242400"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201403052111"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/dd84832f-520e-4e1f-a119-5047a536eeef",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "02454cam a2200601 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061175"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20140805164105.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1988 xx 100 0 eng c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)18135930"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3540192360"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "3-540-19236-0"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0387192360"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0-387-19236-0"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ014244489"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "eng"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "engl."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "082"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "516.3/5"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SA - SP"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 830 - SI 910"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic geometry, Sundance 1986 :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "proceedings of a conference held at Sundance, Utah, August 12 - 19, 1986 /"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "A. Holme ... (eds.)"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "246"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "9"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic geometry, Sundance nineteen hundred and eighty-six"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Berlin ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Heidelberg [u.a.] :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Springer,"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1988"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "320 S. :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "graph. Darst."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "490"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics ;"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1311"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb; 580 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4001161-6"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208841520"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraische Geometrie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "g"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Sundance <Utah, 1986>"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4001161-6"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208841520"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraische Geometrie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "A"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "f"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kongress"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "700"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Holme, Audun"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1938-"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Hrsg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)123106435"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)161472060"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "edt"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "775"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "i"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Online-Ausg."
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Holme, Audun"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "t"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic Geometry Sundance 1986"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)404657192"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "830"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics <Berlin>"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1311"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "w"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)015703274"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "m"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576;springer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "q"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "image/jpeg"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://swbplus.bsz-bw.de/bsz014244489cov.htm"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "v"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20091126143456"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Cover"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "856"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "4"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "2"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "u"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1792958&custom%5Fatt%5F2=simple%5Fviewer"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "y"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Algebraic geometry"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "3"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Inhaltsverzeichnis"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "a001"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gkko"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "SI 850"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Mathematik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schriftenreihen in der alphabetischen Ordnung nach Verfassern"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Lecture notes in mathematics"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9783540192367"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "020"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "9780387192369"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)0008621007"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)SI 850-1311"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "current"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "981"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)Sb4 - 16:1311"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "FHMath"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-15)1416387"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "969"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "900"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Holme, A."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Geometrie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-15"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "107534827:201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-08-01T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "014244489"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201408060609"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "d"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201502081030"
+      } ] ]
+    } ] ]
+  } ]
+}, {
+  "v1" : "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/3ecc9911-d1e9-4a32-b0b4-eaa15f3fd75e",
+  "v2" : [ {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#recordType"
+  }, {
+    "http://www.loc.gov/MARC21/slim#leader" : [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#leaderType"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "01956cam a2200577 4500"
+    } ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#controlfield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "001"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0000061172"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "003"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "005"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "20150211073247.0"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "007"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "tu"
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#controlfieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "008"
+    }, {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "880628s1987 xx m 000 0 ger c"
+    } ] ]
+  }, {
+    "http://www.loc.gov/MARC21/slim#datafield" : [ [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "016"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(OCoLC)220528915"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "035"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-599)BSZ01424361X"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "040"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "e"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rakwb"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "ger"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "041"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "7"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "dt."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "084"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DF 9000"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "rvk"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "D"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DF"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DF 9000 - DF 9009"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "9"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DF 9000"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "100"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Ihlenfeld, Christiane"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)164870008"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "245"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreativität und Vorurteil :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "soziale Kreativität, e. Möglichkeit zum Abbau vorurteilsvoller Einstellungen / "
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "von Christiane Ihlenfeld"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "260"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1987"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "300"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "464 S. :"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "graph. Darst."
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "502"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Münster, Univ., Diss., 1988."
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "591"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "720 ff. bvb; 580 ff. bvb"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4032903-3"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)208999248"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Kreativität"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4064037-1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209151420"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Vorurteil"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "0"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4064037-1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209151420"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Vorurteil"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "D"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "s"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-588)4055891-5"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "0"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-576)209115777"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "2"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "gnd"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Sozialpsychologie"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "689"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "1"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "5"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-576"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "751"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Münster (Westf)"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "4"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "uvp"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "druck"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "935"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "hs"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "936"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : "r"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : "v"
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DF 9000"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines und Deutschland"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Pädagogik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Systematische Pädagogik"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Sozialisation, Soziales Lernen"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "k"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Allgemeines und Deutschland"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "982"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-Ch1)000000108936"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "971"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "M"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "x"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "1"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-Ch1)500175277"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "971"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "HS"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "983"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "(DE-14)1311413"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "984"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "B"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schöpferische Begabung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Schöpferische Leistung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Creativity"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Das Schöpferische"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Produktionsästhetik"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Soziales Vorurteil"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Vorgefasste Meinung"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Ressentiment"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Stereotyp"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "950"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "Psychologie"
+      } ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-14"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2014-03-15T17:03:39Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "852"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "DE-Ch1"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "z"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "2005-10-05T00:00:00Z"
+      } ] ]
+    } ], [ {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#datafieldType"
+    }, {
+      "http://www.loc.gov/MARC21/slim#tag" : "980"
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind1" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#ind2" : " "
+    }, {
+      "http://www.loc.gov/MARC21/slim#subfield" : [ [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "a"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "01424361X"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "b"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "0"
+      } ], [ {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : "http://www.loc.gov/MARC21/slim#subfieldType"
+      }, {
+        "http://www.loc.gov/MARC21/slim#code" : "c"
+      }, {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value" : "201502120428"
+      } ] ]
+    } ] ]
+  } ]
+} ]

--- a/converter/src/test/resources/misc_del152.task.morph.xml
+++ b/converter/src/test/resources/misc_del152.task.morph.xml
@@ -1,0 +1,43 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<metamorph xmlns="http://www.culturegraph.org/metamorph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" entityMarker="&#30;" version="1" xsi:schemaLocation="http://www.culturegraph.org/metamorph metamorph.xsd">
+    <meta>
+        <name>mapping1f230521-42bf-e97b-0736-1d70481cac21</name>
+    </meta>
+    <rules>
+        <combine flushWith="http://www.loc.gov/MARC21/slim#datafield" includeSubEntities="true" name="@datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__" reset="true" sameEntity="true" value="${datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__.filtered}">
+            <if>
+                <all flushWith="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.loc.gov/MARC21/slim#code" includeSubEntities="true" name="CONDITION_ALL" reset="true">
+                    <data source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#tag">
+                        <regexp match="590"/>
+                    </data>
+                    <data source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.loc.gov/MARC21/slim#code">
+                        <regexp match="a|b"/>
+                    </data>
+                </all>
+            </if>
+            <data name="datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__.filtered" source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.w3.org/1999/02/22-rdf-syntax-ns#value"/>
+        </combine>
+        <combine flushWith="http://www.loc.gov/MARC21/slim#datafield" includeSubEntities="true" name="@datafield_subfield_value__10042913-dc92-be08-141e-0d2cb6714e2d__0__" reset="true" sameEntity="true" value="${datafield_subfield_value__10042913-dc92-be08-141e-0d2cb6714e2d__0__.filtered}">
+            <if>
+                <all flushWith="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.loc.gov/MARC21/slim#code" includeSubEntities="true" name="CONDITION_ALL" reset="true">
+                    <data source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#tag">
+                        <regexp match="980"/>
+                    </data>
+                    <data source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.loc.gov/MARC21/slim#code">
+                        <regexp match="b"/>
+                    </data>
+                </all>
+            </if>
+            <data name="datafield_subfield_value__10042913-dc92-be08-141e-0d2cb6714e2d__0__.filtered" source="http://www.loc.gov/MARC21/slim#datafield&#30;http://www.loc.gov/MARC21/slim#subfield&#30;http://www.w3.org/1999/02/22-rdf-syntax-ns#value"/>
+        </combine>
+        <data name="http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_del152" source="@__TRANSFORMATION_OUTPUT_VARIABLE__0d94c710-0c3c-13ea-fc4e-6e49db7ba5de__3"/>
+        <data name="@componente4a30dfd-6f9d-e74f-1ca6-f2f7f803a621" source="@datafield_subfield_value__10042913-dc92-be08-141e-0d2cb6714e2d__0__">
+            <equals string="15"/>
+        </data>
+        <all flushWith="record" name="@__TRANSFORMATION_OUTPUT_VARIABLE__0d94c710-0c3c-13ea-fc4e-6e49db7ba5de__3" reset="true" value="${datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__}">
+            <data name="componente4a30dfd-6f9d-e74f-1ca6-f2f7f803a621" source="@componente4a30dfd-6f9d-e74f-1ca6-f2f7f803a621"/>
+            <data name="datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__" source="@datafield_subfield_value__b8b79456-73c5-c575-f61f-71a4f02ee707__0__"/>
+        </all>
+    </rules>
+    <maps/>
+</metamorph>

--- a/converter/src/test/resources/misc_del152.task.plain.json
+++ b/converter/src/test/resources/misc_del152.task.plain.json
@@ -1,0 +1,3222 @@
+{
+  "name": "Project: äölkäölk (583a5abb-d653-d431-9a21-8d3e868d2286)",
+  "description": "With mappings: test",
+  "job": {
+    "mappings": [
+      {
+        "uuid": "e1e8129d-9da7-b343-4c69-9031f6f30ecd",
+        "name": "test",
+        "transformation": {
+          "uuid": "5ab9b16a-d58f-3bea-4fde-bd95dbc20606",
+          "name": "transformation",
+          "description": "transformation",
+          "function": {
+            "type": "Transformation",
+            "uuid": "15f5b23d-1bae-a529-c8e7-dbeda0f4a7d0",
+            "name": "transformation",
+            "description": "transformation",
+            "components": [
+              {
+                "uuid": "d0ea0a0b-d629-a18a-1997-536220361453",
+                "name": "component6ba242bb-f56d-3dc0-ecbd-9348f9eedae7",
+                "description": "{\"x\":\"datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518\",\"y\":0}",
+                "function": {
+                  "type": "Function",
+                  "uuid": "Function-d6eff38b-f967-477c-ab70-6ee53dd3109a",
+                  "name": "all",
+                  "description": "Outputs an unnamed literal with -true- as value if all contained statements fire.",
+                  "function_description": {
+                    "name": "all",
+                    "dsl": "metafacture",
+                    "reference": "all",
+                    "description": "Outputs an unnamed literal with -true- as value if all contained statements fire.",
+                    "parameters": {
+                      "value": {
+                        "type": "text",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "parameters": [
+                    "value"
+                  ]
+                },
+                "parameter_mappings": {
+                  "inputString": "datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518__0__,datafield_subfield_value__e5601cfd-7490-8d55-2b49-fae3ce3ef760__0__",
+                  "value": "${datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518__0__}"
+                }
+              }
+            ],
+            "function_description": null,
+            "parameters": null
+          },
+          "input_components": null,
+          "output_components": null,
+          "parameter_mappings": {
+            "__TRANSFORMATION_OUTPUT_VARIABLE__583a5abb-d653-d431-9a21-8d3e868d2286__2": "__OUTPUT_MAPPING_ATTRIBUTE_PATH_INSTANCE__583a5abb-d653-d431-9a21-8d3e868d2286__2",
+            "datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518__0__": "datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518__0__",
+            "datafield_subfield_value__e5601cfd-7490-8d55-2b49-fae3ce3ef760__0__": "datafield_subfield_value__e5601cfd-7490-8d55-2b49-fae3ce3ef760__0__"
+          }
+        },
+        "input_attribute_paths": [
+          {
+            "type": "MappingAttributePathInstance",
+            "uuid": "e5601cfd-7490-8d55-2b49-fae3ce3ef760",
+            "name": "datafield_subfield_value__e5601cfd-7490-8d55-2b49-fae3ce3ef760__0__",
+            "attribute_path": {
+              "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+              "attributes": [
+                {
+                  "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                  "name": "datafield",
+                  "uri": "http://www.loc.gov/MARC21/slim#datafield"
+                },
+                {
+                  "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                  "name": "subfield",
+                  "uri": "http://www.loc.gov/MARC21/slim#subfield"
+                },
+                {
+                  "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                  "name": "value",
+                  "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                }
+              ]
+            },
+            "filter": {
+              "uuid": "27fd2436-2637-3e22-00fe-a35adb9d6960",
+              "name": null,
+              "expression": "[{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#tag\":{\"type\":\"REGEXP\",\"expression\":\"980\"}},{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#subfield\\u001ehttp://www.loc.gov/MARC21/slim#code\":{\"type\":\"REGEXP\",\"expression\":\"b\"}}]"
+            }
+          },
+          {
+            "type": "MappingAttributePathInstance",
+            "uuid": "13ee1bdd-b5bf-10a7-8741-d32bd5267518",
+            "name": "datafield_subfield_value__13ee1bdd-b5bf-10a7-8741-d32bd5267518__0__",
+            "attribute_path": {
+              "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+              "attributes": [
+                {
+                  "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                  "name": "datafield",
+                  "uri": "http://www.loc.gov/MARC21/slim#datafield"
+                },
+                {
+                  "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                  "name": "subfield",
+                  "uri": "http://www.loc.gov/MARC21/slim#subfield"
+                },
+                {
+                  "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                  "name": "value",
+                  "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                }
+              ]
+            },
+            "filter": {
+              "uuid": "8b517de6-7d92-aecb-7784-0f40cd7623e7",
+              "name": null,
+              "expression": "[{\"http://www.loc.gov/MARC21/slim#datafield\\u001ehttp://www.loc.gov/MARC21/slim#tag\":{\"type\":\"REGEXP\",\"expression\":\"590\"}}]"
+            }
+          }
+        ],
+        "output_attribute_path": {
+          "type": "MappingAttributePathInstance",
+          "uuid": "f7223fd3-fe77-14b3-c263-d9988d8cda6a",
+          "name": "__OUTPUT_MAPPING_ATTRIBUTE_PATH_INSTANCE__583a5abb-d653-d431-9a21-8d3e868d2286__2",
+          "attribute_path": {
+            "uuid": "AttributePath-271f11c0-8a71-462b-ade3-cb4761e6b80b",
+            "attributes": [
+              {
+                "uuid": "Attribute-ee83c47a-5c4e-47e6-9351-e5fbe416095b",
+                "name": "misc_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_del152"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "input_data_model": {
+    "uuid": "91e6904b-b54c-b990-01c0-9f1d14793114",
+    "name": "ölkjölkjöklj",
+    "description": null,
+    "configuration": {
+      "uuid": "3b21e6de-0098-766d-30f6-5328d61c4c8c",
+      "name": null,
+      "description": null,
+      "resources": [
+        {
+          "uuid": "Resource-ece0b2f1-4aac-4df7-a27c-b3f59fd81cf4"
+        }
+      ],
+      "parameters": {
+        "storage_type": "marc21",
+        "record_tag": "record"
+      }
+    },
+    "schema": {
+      "uuid": "Schema-781d73f0-d115-462e-9b4c-ec23e4251c8d",
+      "name": "marc21 schema",
+      "attribute_paths": [
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c430826b-4bd6-4e29-9005-7eb795778076",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0f13ed14-7920-4832-ac67-5ceca147bd87",
+            "attributes": [
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ed6b3e41-d208-48cf-966a-9ea0e52ccd57",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a2eab260-c941-4fdc-960b-1eb457cee43b",
+            "attributes": [
+              {
+                "uuid": "Attribute-91326f5c-06db-4866-99c2-81fc27602267",
+                "name": "type",
+                "uri": "http://www.loc.gov/MARC21/slim#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0658cf97-4496-4b55-ab00-568b77ca7d93",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5ce0f899-83ba-4c3f-a66a-9c9b11dfcdc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-27b90dc4-fd53-414e-b389-76973ce68fb4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-42e72690-79c1-435f-8aad-faa6fd7da855",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9d32093-3689-4ddf-82b9-f1b0bbd232a8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c3c678a8-1fcc-4208-ac54-cb62cf2447d4",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ab0885ce-f6e9-4e5b-9a4b-d81750141afc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d7d218fa-cc94-4974-a3eb-4d4529e4d93f",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1a1fdc71-10ea-4cb3-92ad-f5537c73dad4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e7a3f55e-2726-4b5a-a03e-41cb177cde32",
+            "attributes": [
+              {
+                "uuid": "Attribute-fae3e549-c8f4-4210-b667-f47049cb12b8",
+                "name": "leader",
+                "uri": "http://www.loc.gov/MARC21/slim#leader"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-9d24e826-c70e-4691-921c-e2022ec13d5c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5560885f-b1d3-41d3-9914-e2eb6c7301cb",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc9c0051-4d1d-4c16-ab7a-ae722457f636",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b132ca2c-94d5-4db9-9c3c-f6046b78d9c5",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-74492463-6ee5-4ca5-b2d5-ad534babca8c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c02508a4-3022-4023-8fb9-ff56d3de3ab7",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0f4bb69d-03e2-4685-9d5d-22b26eb7d83e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bf27673a-71d9-44b9-aecd-ad241456478c",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc053aae-512b-4a19-9192-81496833e81e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8646a949-f1d2-4bac-9eba-8a0cd84ca4f9",
+            "attributes": [
+              {
+                "uuid": "Attribute-6ff2d19f-7028-4a2f-99ef-954fa27df505",
+                "name": "controlfield",
+                "uri": "http://www.loc.gov/MARC21/slim#controlfield"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f40b07e0-a6d7-486c-a1e5-362b7afdff34",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c4043365-18b4-408a-9aa4-6de7a5d4d007",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ec4e249f-9b56-4206-bcfb-60d45f268636",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-33e9a9cb-ccfc-4d77-89b2-503f09d448e8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5f0bd291-d311-404b-a1d8-c15426e0111c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-70352f17-81c3-4854-84b0-a3dd850317ba",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eb34d1aa-b76e-4ca2-93b6-cfcbad7a849b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7b6ea240-aa91-444a-937f-6efc36d0ddc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3c325fcd-5f86-4d93-8530-468872c426a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-debd4384-3258-4e4b-a925-f0f32702fec8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-7eb8941b-59a4-434d-a443-4540a2b896bf",
+                "name": "ind1",
+                "uri": "http://www.loc.gov/MARC21/slim#ind1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-275b376d-ae3a-4f3f-8705-0a13f86c6aba",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1db98d03-ab89-4d28-8f13-6c87cf7cd3b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-8653be0d-5384-4110-bf66-8c4998072c3c",
+                "name": "ind2",
+                "uri": "http://www.loc.gov/MARC21/slim#ind2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e2401b88-3a04-4f23-81d4-2e16a38522e0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5a6f915f-8fac-45d7-93d5-68b236cb376c",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ace8ef6b-a082-46f8-82cf-89e4ff36b968",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7b18b43f-1c59-4c25-a44b-088b9304e663",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-940425c7-cf49-4c52-a8e4-7b22506b475f",
+                "name": "type",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-12358ff1-0183-4201-a163-011c5fc7b4d9",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e9df1173-1792-4d25-927e-cd2abad97688",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+                "name": "id",
+                "uri": "http://www.loc.gov/MARC21/slim#id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-bc28eb70-8167-4c1b-98c4-4609f7255866",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-81bdf315-f7fd-4e23-b9da-a7c5381d4f31",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-01a2281f-dbe9-4c9a-8cc0-47576b48261a",
+                "name": "code",
+                "uri": "http://www.loc.gov/MARC21/slim#code"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3cf47be1-0929-42b0-85c3-eb911c2534ec",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+                "name": "value",
+                "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+              }
+            ]
+          },
+          "sub_schema": null
+        }
+      ],
+      "record_class": {
+        "uuid": "Clasz-2e24c5d4-db16-48b9-a8e7-f229287c55e4",
+        "name": "recordType",
+        "uri": "http://www.loc.gov/MARC21/slim#recordType"
+      },
+      "content_schema": {
+        "uuid": "ContentSchema-7bdcaacc-e0e4-43fd-949c-4a42fb54d99d",
+        "name": "marc21 content schema",
+        "record_identifier_attribute_path": {
+          "uuid": "AttributePath-5ce0f899-83ba-4c3f-a66a-9c9b11dfcdc1",
+          "attributes": [
+            {
+              "uuid": "Attribute-6de82e43-d0a0-496a-a728-4bf393a35eba",
+              "name": "id",
+              "uri": "http://www.loc.gov/MARC21/slim#id"
+            }
+          ]
+        },
+        "key_attribute_paths": [
+          {
+            "uuid": "AttributePath-7b6ea240-aa91-444a-937f-6efc36d0ddc1",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-fe4a7309-e300-4b3d-96f8-e2c72e2242dc",
+                "name": "tag",
+                "uri": "http://www.loc.gov/MARC21/slim#tag"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-debd4384-3258-4e4b-a925-f0f32702fec8",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-7eb8941b-59a4-434d-a443-4540a2b896bf",
+                "name": "ind1",
+                "uri": "http://www.loc.gov/MARC21/slim#ind1"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-1db98d03-ab89-4d28-8f13-6c87cf7cd3b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-8653be0d-5384-4110-bf66-8c4998072c3c",
+                "name": "ind2",
+                "uri": "http://www.loc.gov/MARC21/slim#ind2"
+              }
+            ]
+          },
+          {
+            "uuid": "AttributePath-81bdf315-f7fd-4e23-b9da-a7c5381d4f31",
+            "attributes": [
+              {
+                "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+                "name": "datafield",
+                "uri": "http://www.loc.gov/MARC21/slim#datafield"
+              },
+              {
+                "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+                "name": "subfield",
+                "uri": "http://www.loc.gov/MARC21/slim#subfield"
+              },
+              {
+                "uuid": "Attribute-01a2281f-dbe9-4c9a-8cc0-47576b48261a",
+                "name": "code",
+                "uri": "http://www.loc.gov/MARC21/slim#code"
+              }
+            ]
+          }
+        ],
+        "value_attribute_path": {
+          "uuid": "AttributePath-38b331c3-9d18-404b-bbd2-c20d61a1820a",
+          "attributes": [
+            {
+              "uuid": "Attribute-431c0960-da78-485d-bb7e-f6645b3dd52a",
+              "name": "datafield",
+              "uri": "http://www.loc.gov/MARC21/slim#datafield"
+            },
+            {
+              "uuid": "Attribute-59f8187e-5ac3-4ef9-82cc-35212a5f9a1b",
+              "name": "subfield",
+              "uri": "http://www.loc.gov/MARC21/slim#subfield"
+            },
+            {
+              "uuid": "Attribute-06d09c8d-465d-417c-9b7f-0a3a2ca78b2d",
+              "name": "value",
+              "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+            }
+          ]
+        }
+      }
+    },
+    "deprecated": false,
+    "data_resource": {
+      "uuid": "Resource-ece0b2f1-4aac-4df7-a27c-b3f59fd81cf4",
+      "name": "fincmarc_small2.xml",
+      "description": "ölkjölkj",
+      "type": "FILE",
+      "configurations": [
+        {
+          "uuid": "3b21e6de-0098-766d-30f6-5328d61c4c8c",
+          "name": null,
+          "description": null,
+          "resources": [
+            {
+              "uuid": "Resource-ece0b2f1-4aac-4df7-a27c-b3f59fd81cf4"
+            }
+          ],
+          "parameters": {
+            "storage_type": "marc21",
+            "record_tag": "record"
+          }
+        }
+      ],
+      "resource_attributes": {
+        "path": "/home/tgaengler/git/dswarm/controller/tmp/resources/fincmarc_small2.xml",
+        "filesize": -1,
+        "filetype": "application/xml"
+      }
+    }
+  },
+  "output_data_model": {
+    "uuid": "5fddf2c5-916b-49dc-a07d-af04020c17f7",
+    "name": "Internal Data Model finc Solr",
+    "description": "Internal Data Model finc Solr",
+    "schema": {
+      "uuid": "Schema-5664ba0e-ccb3-4b71-8823-13281490de30",
+      "name": "finc Solr schema",
+      "attribute_paths": [
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-45510f73-7e52-4298-b527-a63b196e4146",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4b2a78dd-eb54-4b07-8099-f91cab891ee3",
+            "attributes": [
+              {
+                "uuid": "Attribute-ec24b350-09c3-4cfc-9676-cfba300063a0",
+                "name": "_version_",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/_version_"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f1244815-c0c3-4fdc-bdd0-388dbc7d8a86",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a0fdd134-0674-4138-9200-b06640862359",
+            "attributes": [
+              {
+                "uuid": "Attribute-e97702dd-f890-4b01-9c94-87eccb54737e",
+                "name": "recordtype",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/recordtype"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cee4d6ad-7eb9-435c-bdde-10ba3c86d958",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b6d40691-cffd-4716-b417-6d4e7204d8d2",
+            "attributes": [
+              {
+                "uuid": "Attribute-7e5995f2-a3e1-4807-b570-bb938de6a4e0",
+                "name": "id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a0b9799e-96d1-45a3-86f0-85e1cd628291",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bd398c12-5a0c-42d5-96ae-e7fdfd02314a",
+            "attributes": [
+              {
+                "uuid": "Attribute-43d75a5b-c1af-4995-acea-612ad4503e51",
+                "name": "fullrecord",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fullrecord"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1e30bea1-4f8b-4857-9c43-b86e45084ce8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e2347424-50d1-45ff-abf1-12e008831f5a",
+            "attributes": [
+              {
+                "uuid": "Attribute-4ca9d98f-6a94-4314-8dae-5a4a7fb9a982",
+                "name": "itemdata",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/itemdata"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-42a3304f-9419-467e-a78d-7a6f8917f58b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1b152978-09fc-4c02-8edb-bed1dbbf0e4f",
+            "attributes": [
+              {
+                "uuid": "Attribute-2c7f665e-9c3d-43c1-826c-63155c7674a7",
+                "name": "marc_error",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/marc_error"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2cb48c32-e9d4-43db-a01a-be01e83a6250",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f3bb6525-05c4-4923-8daf-bc3f4c941d81",
+            "attributes": [
+              {
+                "uuid": "Attribute-3526ad77-e01a-4559-baf9-67cad2449850",
+                "name": "allfields",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/allfields"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-82b2aa67-6c2d-41ae-835d-ecb57610a56c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-72ebf5f4-bd2f-41f0-94b7-64bf82edeb3b",
+            "attributes": [
+              {
+                "uuid": "Attribute-f08f19aa-ae88-432b-bc6d-a6d54ab40b29",
+                "name": "allfields_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/allfields_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-40bd661b-e9f5-4406-8638-8f6dcf242327",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2e4a9e81-b17c-4da6-ad29-5b9349168a6d",
+            "attributes": [
+              {
+                "uuid": "Attribute-55578b4f-e172-41cd-bdd6-b135630b3449",
+                "name": "fulltext",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fulltext"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1c7e8c24-e1e6-459a-95c0-f5ddceec5205",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-846c0d34-f9a1-4a9d-829b-aef771d41dee",
+            "attributes": [
+              {
+                "uuid": "Attribute-c34d6355-3e8a-4db8-95e5-4f821db92804",
+                "name": "spelling",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/spelling"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-70ac78e4-a9d1-4be8-84d3-894a8d46897c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-6716a9ee-b68c-4f9e-bb4c-cec6150e83bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-ca75340b-7167-4d08-8156-bf0ee2321088",
+                "name": "spellingShingle",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/spellingShingle"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-492a36cb-e2bf-4e18-8c77-b317eeea2a4f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fec00f9e-68ff-41ff-8e4b-cedb25aa0073",
+            "attributes": [
+              {
+                "uuid": "Attribute-f0c2d149-5475-4a00-90e1-0e70f865c358",
+                "name": "mega_collection",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/mega_collection"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a6192e44-904d-4dd3-9fe1-e60e9389dd6e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f7b99506-e4bc-4e10-a203-8d3b959a39af",
+            "attributes": [
+              {
+                "uuid": "Attribute-a508a706-b393-45d0-b2b2-056c51150d93",
+                "name": "mega_toplevel",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/mega_toplevel"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3ed06dd9-64b2-4cad-8bf6-8ce8f27dc99b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2d0c7eaf-e894-4d01-824a-3842ef48f3d5",
+            "attributes": [
+              {
+                "uuid": "Attribute-2ecd4759-c655-4d83-8677-9db666095f2b",
+                "name": "record_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/record_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5ca5a5ff-767e-4f74-a71e-46567f97ec2f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-aae45656-4503-4332-8f46-fbea50449f6a",
+            "attributes": [
+              {
+                "uuid": "Attribute-8054f36c-ccd1-4f60-9408-4217f6bf334d",
+                "name": "source_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/source_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1321437e-4d17-4e64-a2a3-3988b4a81912",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-09296992-9dab-44c1-9ff8-5caf4e9bb437",
+            "attributes": [
+              {
+                "uuid": "Attribute-07eadaef-5a5f-4bc8-98f1-2fb36fb13a24",
+                "name": "authorized_mode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/authorized_mode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3f05df93-6d8f-44f3-bae8-0d43b1ead319",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1ae2437a-c3b9-4276-8cbd-1d1ac32cffeb",
+            "attributes": [
+              {
+                "uuid": "Attribute-0be57ff7-b2ee-4346-b4ae-f5049b6bb210",
+                "name": "institution",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/institution"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cdf8f26a-b0b7-4c45-9a81-4a31ac43a969",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5f61302b-3a87-454e-9754-1074981248af",
+            "attributes": [
+              {
+                "uuid": "Attribute-62f09731-f931-4cdf-a4ee-cc5e8d46efe3",
+                "name": "signatur",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/signatur"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e4f31787-e3ea-40ce-8dc6-3ed418c7ca93",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7e496286-3572-49f8-a3aa-ee9dd640419a",
+            "attributes": [
+              {
+                "uuid": "Attribute-83afc0fa-c857-4b36-88e0-63284b987b69",
+                "name": "barcode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/barcode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-863d4278-b6a0-4183-931b-ad770767bcb2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a9e0645f-fb30-4283-b2ed-91fa7960c78d",
+            "attributes": [
+              {
+                "uuid": "Attribute-bd455c81-2edf-446e-8107-3d9df42af826",
+                "name": "rsn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rsn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-abe8ada5-e4ce-4c46-b2db-d1e36be5b820",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bb13fc0d-33cd-4137-a9b4-a080099ccfe8",
+            "attributes": [
+              {
+                "uuid": "Attribute-e2528674-db68-4f5c-86c8-b72d744d941d",
+                "name": "access_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/access_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-779b98ee-721a-4a7c-90f6-c1d00870735f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f6add4d4-153f-4dc3-b86d-48b998ce6ac7",
+            "attributes": [
+              {
+                "uuid": "Attribute-272c8d6e-6bc1-4744-b613-e66469dd23c6",
+                "name": "author_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e5824903-4602-4475-b4a5-dddc59c28d30",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-117e6917-2e43-41ef-af45-a575bc42f3ca",
+            "attributes": [
+              {
+                "uuid": "Attribute-6c20d048-81ad-4baa-a510-ca0281e0b51c",
+                "name": "topic_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9868f45-9b3f-4feb-b2fc-e54ade764941",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-de8fda4c-3da1-446c-a1f4-a0fb3a176278",
+            "attributes": [
+              {
+                "uuid": "Attribute-3bccbb7d-0fd9-4a7d-9fef-f66adcc8a36b",
+                "name": "author_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c0ff1dd3-dfa5-46b7-a017-d55ac26137a7",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5a253efd-6c3e-4143-9d97-704b9c5d35e0",
+            "attributes": [
+              {
+                "uuid": "Attribute-619200ad-9d94-4258-8cf5-8fc125b4b211",
+                "name": "author_corp_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f8fa60a4-30b5-4c69-aa98-8fd7cf5ab2f8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-37d5b54b-224f-486b-8721-22305a7fe912",
+            "attributes": [
+              {
+                "uuid": "Attribute-7fb9dffe-b6a1-46ec-8267-18d2cacedcce",
+                "name": "topic_ref",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_ref"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7874ddeb-5e32-43bd-bb85-53dbb52e3bb0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-afe323e3-f8e5-4ed1-b0e1-6f090601dd67",
+            "attributes": [
+              {
+                "uuid": "Attribute-187bb5af-b2f5-4fe4-987e-fdfd92ead455",
+                "name": "multipart_set",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_set"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ef186d99-ec60-4406-b18e-b24faf18494c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-32437a46-4773-4d5a-9002-70e0a895ce61",
+            "attributes": [
+              {
+                "uuid": "Attribute-400148f4-05d6-43bb-95bc-9a787047db85",
+                "name": "multipart_link",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_link"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-92f0483e-859e-499b-8c2d-8cb7ea1014a4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-af3d5c10-396c-4c41-80ff-4fda7693981b",
+            "attributes": [
+              {
+                "uuid": "Attribute-047349e7-a3a9-4593-a850-c662578f8234",
+                "name": "multipart_part",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/multipart_part"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-719aef39-cf1e-48d8-9cbe-16a4db17cbb8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-21172cc2-b76a-4255-8690-e8e9c76a02dc",
+            "attributes": [
+              {
+                "uuid": "Attribute-c6c48e35-f2a5-4bb3-909a-36b6474f047b",
+                "name": "purchase",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/purchase"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6970b5a1-de98-4c30-9bad-2320e00459a0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bcc2305d-849f-4faa-b345-555fc71aedff",
+            "attributes": [
+              {
+                "uuid": "Attribute-dc9b3971-26f2-490b-b7cc-ac9da9ac8179",
+                "name": "timecode",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/timecode"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0ed685fe-bb32-4046-9891-0fc477be28e3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d553e96d-e70e-4ecf-afe1-35efe5b2f3cc",
+            "attributes": [
+              {
+                "uuid": "Attribute-c19e8e2c-6c45-4093-9145-fd6238d1d4b1",
+                "name": "misc_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-23887293-3272-40d3-98e6-a3130843f9b2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-271f11c0-8a71-462b-ade3-cb4761e6b80b",
+            "attributes": [
+              {
+                "uuid": "Attribute-ee83c47a-5c4e-47e6-9351-e5fbe416095b",
+                "name": "misc_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-406c726b-45b8-4f97-84d8-2338cc5d109a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-16a0cdf6-3566-47b8-849c-c5262bac789d",
+            "attributes": [
+              {
+                "uuid": "Attribute-16d02c45-5b13-43bb-92df-52ae6a4a4fbb",
+                "name": "misc_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b8fc6274-e22b-4c40-b6c1-de7c71a51897",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-712103f9-8e6e-4f66-a489-d2c8c92175fa",
+            "attributes": [
+              {
+                "uuid": "Attribute-d3d7a931-7369-4fdc-a389-a1520ecaddba",
+                "name": "branch_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b8a2bce7-6e92-4896-9019-8d5fbfd21a9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-feedb067-0177-4976-97d3-ec241eac4602",
+            "attributes": [
+              {
+                "uuid": "Attribute-b8dba465-7683-4c89-a52a-4cdde85bee5b",
+                "name": "branch_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ef1ecf17-5fbd-48c7-915f-e879aa0a14cf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0e7581f0-45c5-4bbf-aba5-5fd0c8881543",
+            "attributes": [
+              {
+                "uuid": "Attribute-70232888-abe0-4ef7-b5fb-b78fc5f0ef1c",
+                "name": "branch_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-156ba2bb-2a68-4129-96c0-17a0891df1a8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bff7fb5b-e974-4816-837a-33f7d4fdb216",
+            "attributes": [
+              {
+                "uuid": "Attribute-84337d64-9ca0-4c40-a296-348d7ae697b7",
+                "name": "branch_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-84a961a7-bd56-484e-9877-4a7f6dc614a0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a557a60b-a71d-4219-a074-fd064ed1af15",
+            "attributes": [
+              {
+                "uuid": "Attribute-aaf69301-375f-46a5-901e-e249d66e6c2e",
+                "name": "branch_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5c21d4db-9258-4c1a-8124-fbcdddf7ad41",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-201363be-9979-49c0-a570-bd9bb75969bc",
+            "attributes": [
+              {
+                "uuid": "Attribute-f69f9f21-2017-4b20-b4d7-74d6eb412dce",
+                "name": "branch_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/branch_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-548d860c-eb41-4ac7-b9b2-ce8ac7d9df64",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88337fb2-f345-4e6f-8522-531f1300dfdc",
+            "attributes": [
+              {
+                "uuid": "Attribute-08709c29-ff3a-47c6-b378-ea83ab38c7f4",
+                "name": "collcode_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-96958b37-5708-45fe-8405-cd30e7612f00",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-029a079a-42b8-4016-b147-eacb3d94309d",
+            "attributes": [
+              {
+                "uuid": "Attribute-98b82015-1af4-440f-9bef-2e794d413961",
+                "name": "collcode_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cb1770c3-2be7-4e48-9b89-ef29014fed88",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8bea53d6-be0a-4dd6-9c3f-96537899950a",
+            "attributes": [
+              {
+                "uuid": "Attribute-dfcc4da9-50d2-4e0f-9f4c-145ffbb544ff",
+                "name": "collcode_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-76e17f5b-d18b-40fb-8c09-5beb4634c34c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-01f57990-2a02-48bf-bee9-0444b5cdc2a6",
+            "attributes": [
+              {
+                "uuid": "Attribute-ab3705e7-736f-4425-9694-deebfb601405",
+                "name": "collcode_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7f4f5b93-c825-4c89-8feb-32ef62d8951b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c7830c0a-1fe2-4d38-8ceb-ac0ca90612ed",
+            "attributes": [
+              {
+                "uuid": "Attribute-d6c38983-1296-4b8e-9e75-b8bdc721f858",
+                "name": "collcode_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-df3b8895-b198-433f-b5c8-160daf8ef79c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-851ed5c4-4746-4114-b915-b0b179cc65bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-bff1a208-fc8b-4ea1-a57a-623c4af32b2e",
+                "name": "collcode_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/collcode_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4d6dc94a-2892-46d3-b3cd-ebc222b42ac7",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-12395c75-af94-4e25-8e85-df0b488cdda5",
+            "attributes": [
+              {
+                "uuid": "Attribute-aeb17052-b0f4-492b-8e16-2a2062108079",
+                "name": "format_de14",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de14"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a6a91254-b444-4732-856a-7f08cb680090",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f234260c-c82e-4ddd-85fa-632bdd7c8207",
+            "attributes": [
+              {
+                "uuid": "Attribute-fef965ba-3019-4a91-b8c3-7722280871ab",
+                "name": "format_de15",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de15"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-de383eda-32f8-4965-aa95-36314fdca715",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a9bbd57b-ef0e-4fd2-adf5-bfa63d7f11ee",
+            "attributes": [
+              {
+                "uuid": "Attribute-7b45f142-ffb7-4324-8cd4-c043c296c401",
+                "name": "format_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cb3c78ac-0d0d-4d79-a84d-cfcf302cfc1a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-002c9305-e671-41b7-a772-aece230de2a3",
+            "attributes": [
+              {
+                "uuid": "Attribute-362c51fd-4644-42d2-8698-102a2368e4c7",
+                "name": "format_dech1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dech1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-07603b06-32ac-4e5f-b589-a056175ea001",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f62c3555-05f8-4008-9cd2-91c9729ebbca",
+            "attributes": [
+              {
+                "uuid": "Attribute-227b906b-34a0-4876-91d8-094169182906",
+                "name": "format_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-02546aae-aa28-4bcd-8759-5912cae084a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9d9db34d-0829-4a25-886c-88446ec1f95a",
+            "attributes": [
+              {
+                "uuid": "Attribute-94828125-bbc7-4a58-9022-2e5e89475825",
+                "name": "format_de520",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de520"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-21d9dcf9-c48b-45a2-a043-f69064e6d0af",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a25a9a1f-86c6-4b66-b1a6-7fe519db11b9",
+            "attributes": [
+              {
+                "uuid": "Attribute-d2b7d786-4fa3-485b-8a79-7d11711e5af4",
+                "name": "format_del189",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_del189"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b78f4b3c-5db5-4241-bd1b-51d076bf2c09",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-67166209-afae-437b-85a9-d9bd6e363539",
+            "attributes": [
+              {
+                "uuid": "Attribute-d178877e-dab7-4c34-865c-f325c92a148f",
+                "name": "format_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-9c6a1d32-05d1-47f2-8ec1-10f0e1b70efc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8bfdf2bd-6174-4702-91fe-913323829cf3",
+            "attributes": [
+              {
+                "uuid": "Attribute-f171aa9a-1c35-41b4-8714-a76156e3b4bb",
+                "name": "format_dezi4",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_dezi4"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f9952ece-bee8-4d5c-8822-d4daddaa4ad8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bd13a37c-4eb7-4b93-b7ba-a75158539ce6",
+            "attributes": [
+              {
+                "uuid": "Attribute-d32ce518-742b-4dcb-917c-a3f830ea96e9",
+                "name": "format_de540",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_de540"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-32004942-ca80-4b3f-9fee-1cd331171de6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-dbb89ec5-f3b1-4c06-b6c9-b5bf3a305259",
+            "attributes": [
+              {
+                "uuid": "Attribute-3dd2dfe9-ddf8-4d30-b569-b96ebb733c60",
+                "name": "format_ded117",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_ded117"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-53f190f1-b92a-443a-a4d4-70baac388bde",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cb249ee6-e2b4-4d5c-ab0c-fe2e1405fa07",
+            "attributes": [
+              {
+                "uuid": "Attribute-c10d2ebf-053d-417f-8eb3-275eecb64340",
+                "name": "format_degla1",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format_degla1"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2a9506bc-2452-41e6-a83b-e45c625a556c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a19a04ff-dc53-4dda-814f-8dc5385881fb",
+            "attributes": [
+              {
+                "uuid": "Attribute-5c2b0bec-acc9-43b0-998d-a44bd149d7e6",
+                "name": "local_heading_facet_del152",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_facet_del152"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-879471b7-eb9a-4fda-a059-849582b140eb",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-55e820c9-8f38-447f-91be-8d566e8cb3ba",
+            "attributes": [
+              {
+                "uuid": "Attribute-19fcf5ef-405b-441e-bce8-1d49ffc1a226",
+                "name": "local_heading_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-dea5f1ac-c510-4a97-b733-cbe8fb13894d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-622ea203-b737-4ae0-b899-6d50f23062ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-61da8eb2-e906-4d4d-88e5-a18292a3b628",
+                "name": "local_heading_facet_dezwi2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_facet_dezwi2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-04af741c-62d3-4aae-86b8-09440f4fb6e0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a3d2aba0-b90c-4694-aba1-fc4fa0e38878",
+            "attributes": [
+              {
+                "uuid": "Attribute-8dd4ff55-a35b-4717-bbeb-7a0a8c4b8c31",
+                "name": "local_heading_del242",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_heading_del242"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-55c6e6d5-327d-49fb-9885-24f98b3f078d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-967ff8bc-d803-4231-9dad-3a6d4b651822",
+            "attributes": [
+              {
+                "uuid": "Attribute-cc88a7e7-64e2-4ce7-899c-22747efe4fc3",
+                "name": "local_class_del242",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/local_class_del242"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1ea5d761-d0c9-4deb-b601-e1e367c450bf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-38f53b9f-5d49-49d1-8419-dda43b2ad0ff",
+            "attributes": [
+              {
+                "uuid": "Attribute-09502570-bc59-432b-a2e4-d2321164ec57",
+                "name": "udk_raw_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_raw_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ae1a72c7-8760-4f99-98c1-a35156701e9f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-6b447de3-1c45-445a-9369-226d98878aab",
+            "attributes": [
+              {
+                "uuid": "Attribute-5e32d285-fcba-46d1-8070-a90bb9ad567c",
+                "name": "udk_facet_de105",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_facet_de105"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a9a8bbe1-0496-463d-b460-cd3b76df03ef",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c222aa48-28f9-4988-8ad3-8e807daad03f",
+            "attributes": [
+              {
+                "uuid": "Attribute-7790bc9b-882f-442d-bea9-117bab8da717",
+                "name": "udk_raw_del189",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/udk_raw_del189"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1d67416c-e1c8-4332-87ce-a99cba0ee2b1",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0325f60b-41c2-4bde-b962-0a15184f2160",
+            "attributes": [
+              {
+                "uuid": "Attribute-e0c2c6bc-125c-4263-9e40-1b0bb47dec8d",
+                "name": "finc_class_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/finc_class_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-62573309-8896-456a-9de7-05599ba55dc0",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-bfdf59ff-5cf9-48b1-918f-9304a1543306",
+            "attributes": [
+              {
+                "uuid": "Attribute-c650f01f-2039-45e6-ad9f-8f55dba32d9e",
+                "name": "zdb",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/zdb"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0136c6af-ad95-4a93-91f0-ac88cd3ef1a6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e5e0c447-3c5d-43f5-ad5f-1a7d7db14092",
+            "attributes": [
+              {
+                "uuid": "Attribute-6d7733d7-b565-4c21-a6c7-902a86fce5af",
+                "name": "format",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/format"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b2d4c8a1-f54c-4203-918b-c447f4977696",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c7b3f4d3-2c55-4540-bfcd-8c62689bfcfb",
+            "attributes": [
+              {
+                "uuid": "Attribute-a6391a20-786f-48f3-a5fa-9301019104cb",
+                "name": "language",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/language"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e3bafb46-a329-46fa-8630-b29f8e645a01",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f2089462-91a6-447a-bf8d-065093bad8d6",
+            "attributes": [
+              {
+                "uuid": "Attribute-55dd3a58-3321-4431-91db-cea98485a496",
+                "name": "author",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2fce5057-48ca-48ad-b6b2-f2c117234cab",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-08a5e77c-777b-4b49-bf34-30dc7e5c0d80",
+            "attributes": [
+              {
+                "uuid": "Attribute-ff02c40b-26bd-40a1-af9f-20e6361c9a2e",
+                "name": "author_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0bca34eb-020c-43d6-b08b-7774a134ede3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a427e79b-9c0c-45c3-a953-b58b0fe05799",
+            "attributes": [
+              {
+                "uuid": "Attribute-3fe3d35d-0513-4712-8f4c-b0acf5ff9daa",
+                "name": "authorStr",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/authorStr"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-497762b6-dc4f-4457-a6a7-98c6e14bf8cf",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f3736cc7-ba6d-4a0b-a6b2-5f4c53e36b77",
+            "attributes": [
+              {
+                "uuid": "Attribute-297878f9-8227-4b3d-9eaa-be2043542a6d",
+                "name": "author2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4ee2b2ba-c619-4fe9-bb14-7ccb49d7cfcd",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f410d8e5-bbc6-4509-aab9-eda69a5a98c8",
+            "attributes": [
+              {
+                "uuid": "Attribute-d3f4b9ef-627f-48cf-8a52-d7e8624c64a5",
+                "name": "author2_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-fb043677-44da-469f-a72d-ca7c502394ea",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e62a26b1-cced-4271-8457-2e08cd52fe62",
+            "attributes": [
+              {
+                "uuid": "Attribute-8f60b09c-5178-4d92-8b65-4f58a1180074",
+                "name": "author_corp",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-8473db9b-a729-4d14-9168-b94974ff0928",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a2afb846-7d7e-4b90-b7f3-4b5d6e30516a",
+            "attributes": [
+              {
+                "uuid": "Attribute-459f7af6-bf42-4c01-858c-b6d3d4a47577",
+                "name": "author_corp_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-91a25bf2-c7bc-4811-ba85-2cceae590b48",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ec8aad81-7c4e-43b0-989d-c69744bee70e",
+            "attributes": [
+              {
+                "uuid": "Attribute-ab45987a-d76c-43f2-be8f-daaa09d9d525",
+                "name": "author_corp2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c71b2225-73e9-4ec6-b15a-94c9dc7ce572",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9ab4b00f-fb83-49ff-bc13-c912651dc6ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-bcae2d56-4272-470e-9d12-e2919bb4ed93",
+                "name": "author_corp2_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_corp2_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-443322e2-a38b-4193-911e-be972820df6f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e90517f6-8d1f-460f-9d7e-bd770525f1ad",
+            "attributes": [
+              {
+                "uuid": "Attribute-f0d72d18-7bab-4779-a8c5-1edee0139405",
+                "name": "author2-role",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author2-role"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eee6f32d-cd7e-4867-b1bf-b2a1b7b1c3be",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-db6fad77-6e64-403e-8f4b-806e97aad02f",
+            "attributes": [
+              {
+                "uuid": "Attribute-3a8a3149-7306-462f-baa1-68266c8c9460",
+                "name": "author_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-46450b18-bd1c-4f66-a414-ef35930cf884",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e457643a-bb33-4c5d-8010-935be46c72e6",
+            "attributes": [
+              {
+                "uuid": "Attribute-371848c1-ea63-418e-99e1-35955686cd40",
+                "name": "author_browse",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_browse"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-40ae93ee-39ed-4ad0-9b81-b83b2b29bb71",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-915f1e48-1330-4805-b6b4-d3dd44e0869e",
+            "attributes": [
+              {
+                "uuid": "Attribute-02c6ee32-24bb-4100-8fff-66a0ff2701db",
+                "name": "author_sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/author_sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-46127f6d-2afb-40d5-8fc6-87af711fd31a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cd17dd86-8f17-4429-a5a3-896614a06890",
+            "attributes": [
+              {
+                "uuid": "Attribute-487a2007-4046-4389-9090-572269dd6f45",
+                "name": "title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-daaf5c43-65b1-4d81-8aca-cbd630904b9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1a875b16-aede-450f-bafe-8a8992470eae",
+            "attributes": [
+              {
+                "uuid": "Attribute-2db2d3c2-b0cb-480d-9a10-4f96c2db9da4",
+                "name": "title_part",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_part"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-50248c52-0a79-4604-b413-2daebda95742",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c0b37a18-45fe-4033-ab03-e24ab531a96f",
+            "attributes": [
+              {
+                "uuid": "Attribute-78641e6d-acbb-4aa1-9227-8e9ea9bc7710",
+                "name": "title_sub",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_sub"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-ad984db9-8b89-4d1c-9d84-e5bb7efcf115",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ec049154-2b01-4e92-a2c6-8bb97c30608a",
+            "attributes": [
+              {
+                "uuid": "Attribute-325bb505-8d38-4601-8a32-4f8a0ab5baae",
+                "name": "title_short",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_short"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-7ba1fb02-7674-4145-b26c-74e70cd822b6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e0c46b4e-0a5a-430d-af4b-d02afa8fb77f",
+            "attributes": [
+              {
+                "uuid": "Attribute-0c1d94be-ceda-45d5-8077-86178d2ccfd0",
+                "name": "title_full",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_full"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4a932a71-1013-4fb0-8dd9-3ff19756bcc8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4c3e93a5-9cc6-4c30-be5e-4b92ee538ea2",
+            "attributes": [
+              {
+                "uuid": "Attribute-04b2a48a-2ccb-45e1-97b0-d045c69d8c55",
+                "name": "title_full_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_full_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e419a38b-56aa-450c-a314-ba499f6ebff5",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e4a85fb9-772d-47c1-8858-3dc424770bd5",
+            "attributes": [
+              {
+                "uuid": "Attribute-96f5e779-9330-4493-8b25-99f1fee1ddad",
+                "name": "title_fullStr",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_fullStr"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-468a8c5e-6dc7-431d-894a-f06a6a2540f3",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-980ad5ba-adbc-41e0-a917-86fa5cf49f38",
+            "attributes": [
+              {
+                "uuid": "Attribute-177d36df-8648-4442-b92d-53ff99be220d",
+                "name": "title_alt",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_alt"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-73015b22-c520-414f-908e-9e5d511e0d36",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a3d19067-81a3-47bb-abd9-932a538da843",
+            "attributes": [
+              {
+                "uuid": "Attribute-5970e8a7-2ae7-4b89-bc8c-8a0719269740",
+                "name": "title_uniform",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_uniform"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4623a91f-d71a-48a3-9fe4-2fa725c99135",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-236a98f2-3fb8-40ac-98d4-e0ef31d7ea2f",
+            "attributes": [
+              {
+                "uuid": "Attribute-47d6b213-b227-4eb1-91a2-9d41d4a9abfd",
+                "name": "title_old",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_old"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6afb9715-709a-4ec5-9280-f07cfbc60608",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-52f3ad2e-2a1d-4e9a-b04a-8105f020d216",
+            "attributes": [
+              {
+                "uuid": "Attribute-92540c74-8b68-427b-819d-e27f29563bbf",
+                "name": "title_new",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_new"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3e6e3518-6e43-4cc9-851d-06a792320547",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0953f733-881d-45b3-94af-f4f1646729a7",
+            "attributes": [
+              {
+                "uuid": "Attribute-99fc6669-2c26-46d7-9c25-afadea3cb76e",
+                "name": "title_sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1a11dbfe-707e-4a42-b117-a49fc378ecd4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b3634a12-60dc-49aa-a0ca-1747871a4a80",
+            "attributes": [
+              {
+                "uuid": "Attribute-427d5dc1-3d53-4958-b81b-2912340592cf",
+                "name": "title_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/title_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4facf7ea-9a9b-4a0a-acc7-c4cd77076e1a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0b49e4fa-dc96-45d3-a147-75ca4c72cc3a",
+            "attributes": [
+              {
+                "uuid": "Attribute-90405ad9-8e89-4900-969c-9a7d83497380",
+                "name": "series",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-48dc195c-afbf-4048-aa44-3feaefcf8708",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ac34bbb0-4766-4129-927d-a315148fc01a",
+            "attributes": [
+              {
+                "uuid": "Attribute-c734c6c5-e450-4b31-b7ac-f65ab0d37fc5",
+                "name": "series2",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series2"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-85137629-1e06-4d9d-b041-57e2eb36ca24",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c6c26618-8368-4221-ae1f-505b2d6ecf5c",
+            "attributes": [
+              {
+                "uuid": "Attribute-e34103b2-42b4-4f0f-99f2-c1e9a3357804",
+                "name": "series_orig",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/series_orig"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b524b8c3-df48-4b04-906a-6cdded6b2374",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-636d3312-7182-44be-8cbe-2c55545ab19b",
+            "attributes": [
+              {
+                "uuid": "Attribute-ca72b45b-472e-48b3-ad46-95efaec41d11",
+                "name": "edition",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/edition"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-05656f8a-e444-4cca-9030-0b7460c69f5f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-c997dd61-6389-43da-b9bb-395c6425f9bb",
+            "attributes": [
+              {
+                "uuid": "Attribute-4ccab8d5-7db5-47e4-b8fc-8a287d03b903",
+                "name": "publisher",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publisher"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5d7ff419-3ed2-4b10-9b36-33b085ba365f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4ad02801-b206-44bd-8fd1-dcbb3b5001bf",
+            "attributes": [
+              {
+                "uuid": "Attribute-975f6c6f-5cd3-439a-a824-9a299c2eefb6",
+                "name": "publishDate",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishDate"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-cdfe71fa-7c9f-4ac7-84aa-cf1a552c7401",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0ba007e8-1eab-4e35-bf39-3d5a2c296dfd",
+            "attributes": [
+              {
+                "uuid": "Attribute-b1433100-bbb5-4115-b750-d3f99e668a37",
+                "name": "publishDateSort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishDateSort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1acadceb-4acc-489a-96b3-4667cef4fb13",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-34a5cfdd-749b-479a-8b87-30b091185c36",
+            "attributes": [
+              {
+                "uuid": "Attribute-5b044e3f-44b2-40dd-89a3-173060b6d407",
+                "name": "imprint",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/imprint"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0547a298-041c-43bd-9378-c71792b5ff8c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1e726577-d19a-4f46-a8a3-f68e3347457a",
+            "attributes": [
+              {
+                "uuid": "Attribute-efb96920-2977-4765-8852-9cfba45ed1d3",
+                "name": "dateSpan",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dateSpan"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a8fe2609-b86d-4696-ba68-a24108873521",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-53f522af-d7e3-4d46-a17b-c9181f11ffd2",
+            "attributes": [
+              {
+                "uuid": "Attribute-de4b7c7a-79f6-47e4-a272-3b5eb4458cbc",
+                "name": "publishPlace",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/publishPlace"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6ab15dfd-5b88-4c6d-8572-8ee5f6bf7a1e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-b8261464-fce9-4a97-900d-3b7063a87b08",
+            "attributes": [
+              {
+                "uuid": "Attribute-67256488-dbbd-4a31-80f1-67248e2eab0e",
+                "name": "physical",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/physical"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-e623576c-416a-4ba9-ba7d-b1f1787fcc36",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-ced60eda-c22f-463e-a561-bba8eb68a0f5",
+            "attributes": [
+              {
+                "uuid": "Attribute-ce1bfb8a-725c-41cc-8b4b-7d1b3338d620",
+                "name": "footnote",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/footnote"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-0c36bcb6-e86e-4c38-8aad-3002b745ad02",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7c8e3dc9-e348-4c80-bc83-2aa8a1630901",
+            "attributes": [
+              {
+                "uuid": "Attribute-1c9321b2-3222-43c7-a837-385e61e100c4",
+                "name": "dissertation_note",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dissertation_note"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f6cd9e8a-236c-4b22-a726-7bdc3fafe31b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d7ce0263-9757-401f-967e-224911d58e74",
+            "attributes": [
+              {
+                "uuid": "Attribute-80e926e9-0006-47b4-8da2-2dadf45ccfce",
+                "name": "performer_note",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/performer_note"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1c6b77b1-d85c-42ec-99b9-9d29762e0094",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a469c3bd-59a7-4f57-a3dc-2b224fe92a19",
+            "attributes": [
+              {
+                "uuid": "Attribute-91b38329-cda8-469b-a544-b5fd99d58d2a",
+                "name": "illustrated",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/illustrated"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6d1bc20b-7e9c-4d7d-a9ff-aa478b76e9c9",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-08560bce-31df-4dcd-ae5d-c0e0f1d806c8",
+            "attributes": [
+              {
+                "uuid": "Attribute-27a96cf4-9d2c-4578-808d-bd85112da750",
+                "name": "contents",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/contents"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-1ad9f73c-58f1-4337-90ae-15448fe02cd5",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-d3b5fd3a-300d-47d8-8ed2-75219ad97e40",
+            "attributes": [
+              {
+                "uuid": "Attribute-c9e6048f-efdb-4338-8d7a-3213a973a0d2",
+                "name": "url",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/url"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d09529c3-79a8-4f18-8337-cf7c88a4f721",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88aca618-9546-459f-849e-f1b95579f93a",
+            "attributes": [
+              {
+                "uuid": "Attribute-c77ea1a6-5e58-4cc2-bdda-244d2952fb58",
+                "name": "urn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/urn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-eddac1de-45ed-4798-8821-c24be427528f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-3a49110f-a49c-4e5b-b154-3a32243bbc43",
+            "attributes": [
+              {
+                "uuid": "Attribute-27041a00-187c-4377-b68d-e7bf3164abfd",
+                "name": "isbn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/isbn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d34e2398-b131-4983-95c3-b194442bfb8e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f17a74bc-e030-434e-933f-7cc91c043e6f",
+            "attributes": [
+              {
+                "uuid": "Attribute-48ca955f-736a-41d5-8d9d-b45434e69d08",
+                "name": "issn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/issn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-523a6892-5a6d-4fd9-90d2-1621b9299c2d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-9b46cf70-8e2a-43fc-b4b4-0a2d21dc7a1a",
+            "attributes": [
+              {
+                "uuid": "Attribute-f027f8d9-9fbe-4893-abae-1ea694777eaa",
+                "name": "isbn_canc",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/isbn_canc"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5381addc-1063-4b9d-b6fa-71079433da15",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-509e8d73-5dab-4dae-96da-e6dbcb578ce3",
+            "attributes": [
+              {
+                "uuid": "Attribute-0ac2737b-6b1a-43d8-99b8-7670710a6959",
+                "name": "ismn",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/ismn"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6cc21fc1-3d78-4880-bc04-d7ebb8080a5c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-70ab5dda-9a58-4c15-8d9c-cef0ec7e2706",
+            "attributes": [
+              {
+                "uuid": "Attribute-386eb59d-7664-48ff-8d54-a8bdd1553cbd",
+                "name": "issn_canc",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/issn_canc"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-22be6fc3-070a-40ee-a5ba-88e84b6ee675",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-86dde771-713d-427e-bf93-2c74a08ec0d5",
+            "attributes": [
+              {
+                "uuid": "Attribute-22eb7275-2d2e-468e-bc04-37b562695c97",
+                "name": "oclc_num",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/oclc_num"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-3eba4a0d-0a8a-440c-85ea-bb8d9e9fd1a1",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fe14cfc9-868c-43c9-9b91-65d385b9cd7a",
+            "attributes": [
+              {
+                "uuid": "Attribute-8034ba82-efd4-4d1d-ba43-bfa545b6a7b9",
+                "name": "topic",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-763d5e9f-f74a-48ba-860f-033a66f26308",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5c5bedb5-e0b3-4889-bad9-be6fc06a3146",
+            "attributes": [
+              {
+                "uuid": "Attribute-d6aa9884-eb9f-4475-9bd1-38ebe6f1461f",
+                "name": "topic_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-a29ec24c-0912-40f0-98e0-dc3b3ea68514",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-75d71cb1-4c4c-4f39-85e5-7f38f102cd0c",
+            "attributes": [
+              {
+                "uuid": "Attribute-e6d0581d-be80-4549-a095-9cc9722b7a2e",
+                "name": "topic_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/topic_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-2e9102fb-d754-4c3a-8c24-4046273bc2b6",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-a392110a-ddb8-4b3e-bc3d-5e312cff0736",
+            "attributes": [
+              {
+                "uuid": "Attribute-6f44cd53-cd16-4940-a6cd-45015f2afe6d",
+                "name": "geogr_code",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/geogr_code"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-910999dd-6064-4bb2-9e8e-ac9ab3e08e89",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-1e4b9c3e-f137-46fd-93d2-d0b19a8de017",
+            "attributes": [
+              {
+                "uuid": "Attribute-e6952569-a1d7-4a67-b09a-3f99a24dc514",
+                "name": "geogr_code_person",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/geogr_code_person"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-77a38ffb-8d50-465e-9c7d-828fec08a52b",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fd26dbc7-a7ce-4174-ac39-487f47640054",
+            "attributes": [
+              {
+                "uuid": "Attribute-fb79a56c-b730-4224-8020-29523b20f44c",
+                "name": "music_heading",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/music_heading"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-c7ae7ead-a6ba-4afb-a3fc-18c27dae0d9a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e013bdd2-a242-4d2c-917b-2f0e8c9514a5",
+            "attributes": [
+              {
+                "uuid": "Attribute-9e028361-0824-4cbb-a857-d88872783401",
+                "name": "music_heading_browse",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/music_heading_browse"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-22fac459-ce7b-4212-8dd1-ae300fedd487",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-cf2ffabb-13e0-4eeb-a1a5-c99816a7799e",
+            "attributes": [
+              {
+                "uuid": "Attribute-e7f51963-01bc-46ad-8b9b-75488cd7b58c",
+                "name": "film_heading",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/film_heading"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-56d5f795-5cf5-4270-ae81-d4d8310add5f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-33cb8e89-49d0-44df-a5b4-f60fd1983eb4",
+            "attributes": [
+              {
+                "uuid": "Attribute-b98e2493-6877-4f21-9dcd-d727437dde60",
+                "name": "dewey-hundreds",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-hundreds"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-309621b1-6be5-4af0-a4a4-6ee1e2a520c4",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-09008fb8-40a1-4aee-ad6c-ed14f0b7280d",
+            "attributes": [
+              {
+                "uuid": "Attribute-60741df0-b13d-4cb7-bc94-45960655db9a",
+                "name": "dewey-tens",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-tens"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-61b82d24-7dba-47b0-aa15-89a2b941264a",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8a70fbed-efcb-4408-b7ce-8c3363fb579c",
+            "attributes": [
+              {
+                "uuid": "Attribute-3a37045f-956e-4be8-8984-b9ee773a6dbf",
+                "name": "dewey-ones",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-ones"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-763777a2-2031-4353-a1cc-c7d89195c519",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-64b045d5-1fbd-478e-ba37-59dc4c705ee7",
+            "attributes": [
+              {
+                "uuid": "Attribute-8beba31c-fac7-4619-a907-ef23388570ff",
+                "name": "dewey-full",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-full"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-fb483db6-9ab3-4d7c-8266-bcbc98680603",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-44bf98f8-1dd7-49bd-8f22-09c91e44549b",
+            "attributes": [
+              {
+                "uuid": "Attribute-8fe04556-7538-43a2-8fe4-6f2d9d399abb",
+                "name": "dewey-sort",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-sort"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-42959947-742b-4f35-b9b1-a222e151e22f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-4b5f473e-42cd-4bdb-a162-a0dd53b4d1da",
+            "attributes": [
+              {
+                "uuid": "Attribute-28d63692-1ed8-47a6-a024-4bdfb5819860",
+                "name": "dewey-raw",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/dewey-raw"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-77c22271-8a39-4f2d-959a-9b1e374a296e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-7a76b8d1-4666-4a39-a2d9-64b0093446b2",
+            "attributes": [
+              {
+                "uuid": "Attribute-b25d0c23-bb48-4c68-b8ad-8277bdde020e",
+                "name": "rvk_facet",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_facet"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4660e13e-2a88-4e5b-86ed-432cdc7ec509",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8deb4cc9-fa96-4e59-ab33-b6b0410975e7",
+            "attributes": [
+              {
+                "uuid": "Attribute-fc57edb2-22c8-4853-9974-a8a027598217",
+                "name": "rvk_label",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_label"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-82dee949-280e-4e8f-8da1-8e07f877bb59",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8403bb86-9324-4ab3-822b-c1b26488ce45",
+            "attributes": [
+              {
+                "uuid": "Attribute-9ec2c755-5a1d-4c24-8fe0-200e917ca608",
+                "name": "rvk_path",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/rvk_path"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-8f0cd9cc-16f2-4fea-879b-4db11447811f",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-e1673ffa-4c4e-4cb2-9a3f-32cac6f4f6ef",
+            "attributes": [
+              {
+                "uuid": "Attribute-ef5fe1cd-1085-4e87-b572-087ac5f41a32",
+                "name": "fulltext_unstemmed",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/fulltext_unstemmed"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d3e466dc-c776-4aca-8954-517f599d89e2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-5cfe2b1c-3710-4bae-968e-2301799d784f",
+            "attributes": [
+              {
+                "uuid": "Attribute-2e8f4f1e-e346-48c9-aa5f-abfcd158ee77",
+                "name": "hierarchytype",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchytype"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-20faaea7-5253-4c4d-b3e4-7498a832060c",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-88be106f-8115-435a-9728-52eb1cb774a8",
+            "attributes": [
+              {
+                "uuid": "Attribute-89d67eeb-843d-4449-9abd-ff1d3a81be43",
+                "name": "hierarchy_top_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_top_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5b9eac9d-8e8d-4e70-ae0e-5133d52bbed8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-10d11291-16bc-48ec-93c2-0f7fa66eb366",
+            "attributes": [
+              {
+                "uuid": "Attribute-34345b9d-aea6-4ad5-8568-3f84e80ed254",
+                "name": "hierarchy_top_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_top_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-faf30109-1d09-4710-a6c4-88493c8951bc",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-f6c9d8c5-8c1d-41f1-b7b8-e7dc93a0c92a",
+            "attributes": [
+              {
+                "uuid": "Attribute-0e424e47-fa90-450a-95e8-b90bb24a8773",
+                "name": "hierarchy_parent_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_parent_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-5442e5a5-0e18-4755-b48d-52df1e783b1d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-51fbce44-f7c6-4c9c-a02e-33d74692bb8c",
+            "attributes": [
+              {
+                "uuid": "Attribute-012edad4-f98f-47de-8935-e3b22d7e9166",
+                "name": "hierarchy_parent_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_parent_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-b0890edf-fcc3-48ba-b70d-4f742bca6cc8",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-fc2137d6-0d94-46a9-a3c2-20cacaac0757",
+            "attributes": [
+              {
+                "uuid": "Attribute-53d34b5b-906b-4ac4-8423-28617ff088b5",
+                "name": "hierarchy_sequence",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/hierarchy_sequence"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-4dec0fc2-ca74-4a62-89f2-85f8d93f422e",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-909adff6-a3ff-4957-9ea5-287cb46aa3a3",
+            "attributes": [
+              {
+                "uuid": "Attribute-1e8679be-06d7-4da9-a4cb-80b7e52ecfb0",
+                "name": "is_hierarchy_id",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/is_hierarchy_id"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-dee9f51c-b6ad-4786-9e02-12e7c077cc66",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-2b040adc-ab6c-45a3-bc17-cb77c9382b61",
+            "attributes": [
+              {
+                "uuid": "Attribute-2a8a468d-71ec-4679-b93a-f0d0ebc67620",
+                "name": "is_hierarchy_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/is_hierarchy_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-d9a75478-c5f3-4fda-a555-6f407baea89d",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-3dbbbe8f-d30c-48b9-baba-358864c4893c",
+            "attributes": [
+              {
+                "uuid": "Attribute-aba9c36f-acb7-4935-928e-519c1a6d68a6",
+                "name": "container_title",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_title"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-659cf4f4-e3af-4b0a-bc4b-b7c947326c77",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-17f137a3-89c0-42c7-9382-9dd28c99bc91",
+            "attributes": [
+              {
+                "uuid": "Attribute-e7ea27db-7ded-4d27-bf17-a4b698c1ab4b",
+                "name": "container_volume",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_volume"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-6f3f3764-25ec-405f-ba78-3e1cacdce137",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-60fc6d36-f229-4f6f-bd63-67658f2c7cac",
+            "attributes": [
+              {
+                "uuid": "Attribute-785b23b5-72c2-4cf4-8ab6-543b6c7c00e1",
+                "name": "container_issue",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_issue"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-571beb5c-aed1-40fc-8f26-2aff6ca483ab",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-8d9aa9b5-4807-4467-8b02-ae044f9907d2",
+            "attributes": [
+              {
+                "uuid": "Attribute-753c3a74-1560-458b-b3aa-d569c296d71f",
+                "name": "container_start_page",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_start_page"
+              }
+            ]
+          },
+          "sub_schema": null
+        },
+        {
+          "type": "SchemaAttributePathInstance",
+          "uuid": "SchemaAttributePathInstance-f6947f40-6a19-4d3e-b435-71a72a7b41c2",
+          "name": null,
+          "attribute_path": {
+            "uuid": "AttributePath-0a73af76-e9f0-4ce4-b852-e0df180fba74",
+            "attributes": [
+              {
+                "uuid": "Attribute-83a14db9-ae35-48e2-9264-0127fbe1b6a9",
+                "name": "container_reference",
+                "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/container_reference"
+              }
+            ]
+          },
+          "sub_schema": null
+        }
+      ],
+      "record_class": {
+        "uuid": "Clasz-2b3ddd78-3876-44eb-bdd9-ae817ca563c8",
+        "name": "RecordType",
+        "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/RecordType"
+      },
+      "content_schema": {
+        "uuid": "ContentSchema-b321979d-f31e-45b7-b687-39b00f7cb440",
+        "name": "finc Solr content schema",
+        "record_identifier_attribute_path": {
+          "uuid": "AttributePath-b6d40691-cffd-4716-b417-6d4e7204d8d2",
+          "attributes": [
+            {
+              "uuid": "Attribute-7e5995f2-a3e1-4807-b570-bb938de6a4e0",
+              "name": "id",
+              "uri": "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/id"
+            }
+          ]
+        },
+        "key_attribute_paths": null,
+        "value_attribute_path": null
+      }
+    },
+    "deprecated": false
+  }
+}

--- a/converter/src/test/resources/misc_del152.task.result.json
+++ b/converter/src/test/resources/misc_del152.task.result.json
@@ -1,0 +1,85 @@
+[
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/edc8b99d-9eeb-495b-b66e-ea3f468f3015": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/24be24bd-b7fb-4d34-98c1-bc2208c6fb95": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/45f7a59a-e684-4ea5-bca2-bebc04bde61f": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/159417cb-3560-4d0b-af35-288445264677": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/cc0ddde4-1c91-4854-94dc-2f92eb4eab38": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/be0d884e-873e-469f-9c6e-4f323ef29e49": [
+      {
+        "http://data.slub-dresden.de/schemas/Schema-5664ba0e-ccb3-4b71-8823-13281490de30/misc_del152": [
+          "Baroque",
+          "orchestra, continuo, voices"
+        ]
+      },
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/057465fc-b327-441f-91ba-86d6e5657e2d": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/ebc2b1bb-965a-476c-955e-f8be08766199": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/0ec7ff0c-8463-44a8-b374-dec8ad540365": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/dd84832f-520e-4e1f-a119-5047a536eeef": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  },
+  {
+    "http://data.slub-dresden.de/datamodels/DataModel-79021e85-02df-45f6-9c0f-73bf21970f50/records/3ecc9911-d1e9-4a32-b0b4-eaa15f3fd75e": [
+      {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://purl.org/ontology/bibo/Document"
+      }
+    ]
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<version.maven.plugin.surefire>2.18.1</version.maven.plugin.surefire>
 		<version.maven.plugin.version>2.1</version.maven.plugin.version>
 		<version.maven.plugin.war>2.6</version.maven.plugin.war>
-		<version.metafacture-core>3.1.11-dswarm-SNAPSHOT</version.metafacture-core>
+		<version.metafacture-core>3.1.12-dswarm-SNAPSHOT</version.metafacture-core>
 		<version.metrics>3.1.2</version.metrics>
 		<version.rxjava>1.0.14</version.rxjava>
 		<version.slf4j.api>1.7.12</version.slf4j.api>


### PR DESCRIPTION
note: this morphscriptbuilder rework covers only the case, when the mapping inputs of the streams that will be collected with the 'all' collector are from the same subentity, e.g., 'datafield' for MARCXML records. the use case where values from streams can be collected where the mapping inputs are from different subentities, e.g., different 'datafield's for MARCXML, is not covered with this modification.
